### PR TITLE
feat(panel): add smooth page and tab transition animations

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,14 +28,15 @@
     "drizzle-orm": "^0.45.1",
     "evlog": "^2.14.1",
     "lucide-react": "catalog:",
+    "motion": "^12.40.0",
     "next": "catalog:",
+    "next-intl": "catalog:",
     "next-themes": "catalog:",
     "qrcode": "^1.5.4",
     "react": "catalog:",
+    "react-country-flag": "catalog:",
     "react-dom": "catalog:",
     "sonner": "catalog:",
-    "next-intl": "catalog:",
-    "react-country-flag": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/src/app/(admin)/admin/nests/[id]/eggs/[eggId]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/nests/[id]/eggs/[eggId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useEffect, useRef, useState } from "react";
-import { motion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { Download, Plus, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -194,6 +194,7 @@ export default function EggDetailPage({
 }) {
   const t = useTranslations("admin.nests");
   const tc = useTranslations("common");
+  const shouldReduceMotion = useReducedMotion();
 
   const TABS: { id: Tab; label: string }[] = [
     { id: "general", label: t("eggTabGeneral") },
@@ -417,7 +418,7 @@ export default function EggDetailPage({
       </div>
 
       <div className="flex-1 overflow-auto px-6 py-5">
-        <motion.div key={tab} initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.15, ease: "easeOut" }}>
+        <motion.div key={tab} initial={shouldReduceMotion ? false : { opacity: 0 }} animate={{ opacity: 1 }} transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.15, ease: "easeOut" }}>
         {tab === "general" && (
           <div className="mx-auto max-w-2xl flex flex-col gap-4">
             <div className="rounded-xl border border-border bg-card shadow-sm">

--- a/apps/web/src/app/(admin)/admin/nests/[id]/eggs/[eggId]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/nests/[id]/eggs/[eggId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { Download, Plus, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -416,6 +417,7 @@ export default function EggDetailPage({
       </div>
 
       <div className="flex-1 overflow-auto px-6 py-5">
+        <motion.div key={tab} initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.15, ease: "easeOut" }}>
         {tab === "general" && (
           <div className="mx-auto max-w-2xl flex flex-col gap-4">
             <div className="rounded-xl border border-border bg-card shadow-sm">
@@ -737,6 +739,7 @@ export default function EggDetailPage({
             </div>
           </div>
         )}
+        </motion.div>
       </div>
     </>
   );

--- a/apps/web/src/app/(admin)/admin/servers/[id]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/servers/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useEffect, useState } from "react";
+import { motion } from "motion/react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useQuery, useMutation } from "@tanstack/react-query";
@@ -202,6 +203,7 @@ export default function AdminServerDetailPage({ params }: { params: Promise<{ id
       </div>
 
       <div className="flex-1 overflow-auto px-6 py-5">
+        <motion.div key={tab} initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.15, ease: "easeOut" }}>
         {tab === "general" && (
           <div className="mx-auto max-w-2xl flex flex-col gap-4">
             <SectionCard title={t("identityTitle")}>
@@ -527,6 +529,7 @@ export default function AdminServerDetailPage({ params }: { params: Promise<{ id
             </ConfirmDialog>
           </div>
         )}
+        </motion.div>
       </div>
     </>
   );

--- a/apps/web/src/app/(admin)/admin/settings/page.tsx
+++ b/apps/web/src/app/(admin)/admin/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect } from "react";
+import { motion } from "motion/react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { Check, Upload, X, Github, ChevronDown, RotateCcw, Copy, Mail, Loader2, ChevronRight } from "lucide-react";
@@ -442,6 +443,7 @@ export default function AdminSettingsPage() {
           </div>
         )}
 
+        <motion.div key={tab} initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.15, ease: "easeOut" }} className="flex flex-col gap-4">
         {tab === "branding" && (
           <>
             <SectionCard title={t("generalTitle")} description={t("generalDesc")}>
@@ -956,6 +958,7 @@ export default function AdminSettingsPage() {
             </SectionCard>
           </>
         )}
+        </motion.div>
       </div>
 
       {/* Test connection modal */}

--- a/apps/web/src/app/(admin)/admin/users/[id]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/users/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
+import { motion } from "motion/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "@tanstack/react-query";
@@ -208,6 +209,7 @@ export default function AdminUserDetailPage({ params }: { params: Promise<{ id: 
       {/* Tab Content */}
       <div className="flex-1 overflow-auto px-6 py-5">
         <div className="mx-auto max-w-2xl flex flex-col gap-4">
+          <motion.div key={tab} initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.15, ease: "easeOut" }} className="flex flex-col gap-4">
 
           {/* ── Overview ── */}
           {tab === "overview" && (
@@ -452,6 +454,7 @@ export default function AdminUserDetailPage({ params }: { params: Promise<{ id: 
               </div>
             </div>
           )}
+          </motion.div>
         </div>
       </div>
     </>

--- a/apps/web/src/app/(panel)/account/page.tsx
+++ b/apps/web/src/app/(panel)/account/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { Copy, Check, Key, Plus, Trash2, Monitor, LogOut, Camera, Link2, Unlink, Download } from "lucide-react";
+import { motion } from "motion/react";
 import QRCode from "qrcode";
 import {
   Dialog,
@@ -1318,9 +1319,16 @@ export default function AccountPage() {
 
       <div className="flex-1 overflow-auto px-6 py-5">
         <div className="mx-auto max-w-2xl">
-          {tab === "profile" && <ProfileTab />}
-          {tab === "api-keys" && <ApiKeysTab />}
-          {tab === "billing" && <BillingTab />}
+          <motion.div
+            key={tab}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.15, ease: "easeOut" }}
+          >
+            {tab === "profile" && <ProfileTab />}
+            {tab === "api-keys" && <ApiKeysTab />}
+            {tab === "billing" && <BillingTab />}
+          </motion.div>
         </div>
       </div>
     </>

--- a/apps/web/src/components/admin-shell.tsx
+++ b/apps/web/src/components/admin-shell.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@struxa/ui/components/sidebar";
 import { AdminSidebar } from "./admin-sidebar";
 import { ThemeProvider } from "./theme-provider";
+import { PageTransition } from "./page-transition";
 
 const SIDEBAR_STORAGE_KEY = "sidebar:open";
 
@@ -30,7 +31,7 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
               <span className="text-sm font-semibold text-foreground">Struxa Admin</span>
               <SidebarTrigger />
             </div>
-            {children}
+            <PageTransition>{children}</PageTransition>
           </SidebarInset>
         </SidebarProvider>
       </div>

--- a/apps/web/src/components/page-transition.tsx
+++ b/apps/web/src/components/page-transition.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { motion } from "motion/react";
+
+export function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <motion.div
+      key={pathname}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2, ease: "easeOut" }}
+      className="flex flex-col flex-1 overflow-hidden"
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/page-transition.tsx
+++ b/apps/web/src/components/page-transition.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { motion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 
 export function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const shouldReduceMotion = useReducedMotion();
   return (
     <motion.div
       key={pathname}
-      initial={{ opacity: 0 }}
+      initial={shouldReduceMotion ? false : { opacity: 0 }}
       animate={{ opacity: 1 }}
-      transition={{ duration: 0.2, ease: "easeOut" }}
+      transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.2, ease: "easeOut" }}
       className="flex flex-col flex-1 overflow-hidden"
     >
       {children}

--- a/apps/web/src/components/panel-shell.tsx
+++ b/apps/web/src/components/panel-shell.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@struxa/ui/components/sidebar";
 import { PanelSidebar } from "./panel-sidebar";
+import { PageTransition } from "./page-transition";
 
 const AUTH_ROUTES = ["/login", "/register", "/forgot-password"];
 const SIDEBAR_STORAGE_KEY = "sidebar:open";
@@ -34,7 +35,7 @@ export function PanelShell({ children }: { children: React.ReactNode }) {
             <span className="text-sm font-semibold text-foreground">Struxa</span>
             <SidebarTrigger />
           </div>
-          {children}
+          <PageTransition>{children}</PageTransition>
         </SidebarInset>
     </SidebarProvider>
   );

--- a/apps/web/src/components/panel-sidebar.tsx
+++ b/apps/web/src/components/panel-sidebar.tsx
@@ -179,7 +179,7 @@ export function PanelSidebar() {
                       }
                       isActive={item.key === activeServerTab}
                       tooltip={item.label}
-                      className="h-auto gap-2 rounded-lg py-2 px-3 text-sm"
+                      className="h-auto gap-2 rounded-lg py-2 px-3 text-sm transition-colors duration-150"
                     >
                       <item.icon className="h-4 w-4" />
                       {item.label}
@@ -200,7 +200,7 @@ export function PanelSidebar() {
                         render={<Link href={item.href as never} />}
                         isActive={pathname === "/" ? item.key === "servers" : pathname.startsWith(item.href) && item.href !== "/"}
                         tooltip={item.label}
-                        className="h-auto gap-2 rounded-lg py-2 px-3 text-sm"
+                        className="h-auto gap-2 rounded-lg py-2 px-3 text-sm transition-colors duration-150"
                       >
                         <item.icon className="h-4 w-4" />
                         {item.label}

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "drizzle-orm": "^0.45.1",
         "evlog": "^2.14.1",
         "lucide-react": "catalog:",
+        "motion": "^12.40.0",
         "next": "catalog:",
         "next-intl": "catalog:",
         "next-themes": "catalog:",
@@ -1071,6 +1072,8 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
+    "framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
+
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
@@ -1276,6 +1279,12 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
+
+    "motion": ["motion@12.40.0", "", { "dependencies": { "framer-motion": "^12.40.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA=="],
+
+    "motion-dom": ["motion-dom@12.40.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg=="],
+
+    "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 


### PR DESCRIPTION
## Summary

Add motion library for fade-in animations on page navigation and same-page tab switches in both panel and admin. Sidebar stays static throughout. SidebarMenuButton active highlight transitions smoothly.

##  Changes

  - Added motion package (motion/react)
  - New PageTransition component — wraps children in PanelShell and AdminShell, keyed to the current pathname so the animation replays on every route change
  - Tab content in /account, /admin/settings, /admin/servers/[id], /admin/users/[id], and /admin/nests/[id]/eggs/[eggId] wrapped with a keyed motion.div for fade on tab switch
  - Added transition-colors duration-150 to SidebarMenuButton so the active highlight shifts smoothly

##  Testing

  - [x] I have tested this manually
  - [x] Existing functionality is unaffected

##  Checklist

  - [x] My changes follow the project's conventions
  - [x] I have updated relevant documentation
  - [x] No secrets or sensitive data are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782447986&installation_id=134947697&pr_number=4&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F4&signature=96aa671802d16472fe314f82c7dcc088b2ae2ce743f10e5e9db90168e5e992fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smooth fade-in animations when switching tabs across admin panels and account settings, respecting reduced-motion preferences
  * Consistent page transition animations on navigation for improved visual continuity
  * Sidebar navigation buttons now include smoother color transition effects for a more polished UI

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/struxadotcloud/struxa/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->