### PR TITLE
feat(extensions): i18n bridge, field outputs, server & admin settings

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -417,7 +417,8 @@
       "statServerId": "Server ID",
       "statNode": "Node",
       "statEgg": "Egg",
-      "statSftpHost": "SFTP Host"
+      "statSftpHost": "SFTP Host",
+      "extensionSettingsDescription": "Settings provided by this extension."
     },
     "activity": {
       "colTimestamp": "Timestamp",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1117,7 +1117,8 @@
       "previewSubjectWelcome": "Welcome!",
       "previewSubjectServerInstall": "Your server is ready",
       "editTemplates": "Edit Templates",
-      "editTemplatesDesc": "Customize the HTML for each outbound email."
+      "editTemplatesDesc": "Customize the HTML for each outbound email.",
+      "extensionPasswordSet": "••••••••  (configured — type to replace)"
     },
     "emailEditor": {
       "backToSettings": "Settings",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
     "@struxa/db": "workspace:*",
     "@struxa/env": "workspace:*",
     "@struxa/extension-host": "workspace:*",
-    "@struxa/extension-sdk": "^1.0.0",
+    "@struxa/extension-sdk": "^1.0.1",
     "@struxa/ui": "workspace:*",
     "@tanstack/react-form": "^1.28.0",
     "@tanstack/react-query": "^5.90.12",

--- a/apps/web/src/app/(admin)/admin/settings/page.tsx
+++ b/apps/web/src/app/(admin)/admin/settings/page.tsx
@@ -1083,7 +1083,7 @@ export default function AdminSettingsPage() {
                             type={field.type === "password" ? "password" : "text"}
                             placeholder={
                               field.type === "password" && field.value === "__set__"
-                                ? "••••••••  (configured — type to replace)"
+                                ? t("extensionPasswordSet")
                                 : (field.placeholder ?? undefined)
                             }
                             value={value === "__set__" ? "" : value}

--- a/apps/web/src/app/(admin)/admin/settings/page.tsx
+++ b/apps/web/src/app/(admin)/admin/settings/page.tsx
@@ -1056,7 +1056,7 @@ export default function AdminSettingsPage() {
                             {field.description && (
                               <p className="text-[11px] text-muted-foreground">{field.description}</p>
                             )}
-                            <Select value={value} onValueChange={setVal}>
+                            <Select value={value} onValueChange={(v) => v !== null && setVal(v)}>
                               <SelectTrigger className="h-[30px] text-sm">
                                 <SelectValue>
                                   {field.options.find((o) => o.value === value)?.label ?? value}

--- a/apps/web/src/app/(admin)/admin/settings/page.tsx
+++ b/apps/web/src/app/(admin)/admin/settings/page.tsx
@@ -187,13 +187,20 @@ function DiscordIcon({ className }: { className?: string }) {
   );
 }
 
-const TABS = ["branding", "seo", "auth", "email"] as const;
-type Tab = (typeof TABS)[number];
+const CORE_TABS = ["branding", "seo", "auth", "email"] as const;
+type CoreTab = (typeof CORE_TABS)[number];
+type Tab = CoreTab | string; // extension tabs use "ext:<extId>:<tabId>"
 
 export default function AdminSettingsPage() {
   const t = useTranslations("admin.settings");
   const [tab, setTab] = useState<Tab>("branding");
   const [needsRestart, setNeedsRestart] = useState(false);
+
+  const { data: extTabs } = useQuery(orpc.extensions.getAdminSettingsTabs.queryOptions());
+  const saveExtSettingsMutation = useMutation(orpc.extensions.saveAdminSettings.mutationOptions());
+  // Unsaved edits per tab key, and save-indicator state
+  const [extDraft, setExtDraft] = useState<Record<string, Record<string, string>>>({});
+  const [extSaved, setExtSaved] = useState<Record<string, boolean>>({});
   const [githubExpanded, setGithubExpanded] = useState(false);
   const [discordExpanded, setDiscordExpanded] = useState(false);
 
@@ -254,6 +261,24 @@ export default function AdminSettingsPage() {
   function markSaved(key: string) {
     setSaved((s) => [...s, key]);
     setTimeout(() => setSaved((s) => s.filter((k) => k !== key)), 2000);
+  }
+
+  function extTabKey(extId: string, tabId: string) {
+    return `ext:${extId}:${tabId}`;
+  }
+
+  function getExtDraft(extId: string, tabId: string, field: { key: string; value: string }) {
+    return extDraft[extTabKey(extId, tabId)]?.[field.key] ?? field.value;
+  }
+
+  async function saveExtTab(extId: string, tabId: string, fields: Array<{ key: string; value: string }>) {
+    const key = extTabKey(extId, tabId);
+    const draft = extDraft[key] ?? {};
+    const values: Record<string, string> = {};
+    for (const f of fields) values[f.key] = draft[f.key] ?? f.value;
+    await saveExtSettingsMutation.mutateAsync({ extId, tabId, values });
+    setExtSaved((prev) => ({ ...prev, [key]: true }));
+    setTimeout(() => setExtSaved((prev) => ({ ...prev, [key]: false })), 2000);
   }
 
   function generalForm() {
@@ -403,8 +428,8 @@ export default function AdminSettingsPage() {
         <h1 className="text-sm font-semibold text-foreground">{t("title")}</h1>
 
         {/* Tab bar */}
-        <div className="flex gap-1 border-b border-border -mb-1">
-          {TABS.map((tab_item) => (
+        <div className="flex gap-1 border-b border-border -mb-1 flex-wrap">
+          {CORE_TABS.map((tab_item) => (
             <button
               key={tab_item}
               type="button"
@@ -421,6 +446,23 @@ export default function AdminSettingsPage() {
                 : t("tabEmail")}
             </button>
           ))}
+          {(extTabs ?? []).map((extTab) => {
+            const key = extTabKey(extTab.extId, extTab.tabId);
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setTab(key)}
+                className={`px-3 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  tab === key
+                    ? "border-foreground text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {extTab.label}
+              </button>
+            );
+          })}
         </div>
 
         {/* Restart banner */}
@@ -958,6 +1000,111 @@ export default function AdminSettingsPage() {
             </SectionCard>
           </>
         )}
+        {(extTabs ?? []).map((extTab) => {
+          const key = extTabKey(extTab.extId, extTab.tabId);
+          if (tab !== key) return null;
+          const allFields = extTab.sections.flatMap((s) => s.fields);
+          return (
+            <div key={key} className="flex flex-col gap-4">
+              {extTab.sections.map((sec, si) => (
+                <SectionCard key={si} title={sec.title} description={sec.description ?? undefined}>
+                  <div className="flex flex-col gap-3">
+                    {sec.fields.map((field) => {
+                      const value = getExtDraft(extTab.extId, extTab.tabId, field);
+                      const setVal = (v: string) =>
+                        setExtDraft((prev) => ({
+                          ...prev,
+                          [key]: { ...(prev[key] ?? {}), [field.key]: v },
+                        }));
+
+                      if (field.type === "toggle") {
+                        return (
+                          <div key={field.key} className="flex items-center justify-between">
+                            <div>
+                              <p className="text-sm font-medium text-foreground">{field.label}</p>
+                              {field.description && (
+                                <p className="text-xs text-muted-foreground mt-0.5">{field.description}</p>
+                              )}
+                            </div>
+                            <Toggle enabled={value === "1"} onChange={(v) => setVal(v ? "1" : "0")} />
+                          </div>
+                        );
+                      }
+
+                      if (field.type === "textarea") {
+                        return (
+                          <div key={field.key} className="flex flex-col gap-1.5">
+                            <label className="text-xs font-medium text-foreground">{field.label}</label>
+                            {field.description && (
+                              <p className="text-[11px] text-muted-foreground">{field.description}</p>
+                            )}
+                            <textarea
+                              rows={3}
+                              className={`${inputClass()} resize-none`}
+                              placeholder={field.placeholder ?? undefined}
+                              value={value}
+                              onChange={(e) => setVal(e.target.value)}
+                            />
+                          </div>
+                        );
+                      }
+
+                      if (field.type === "select" && field.options) {
+                        return (
+                          <div key={field.key} className="flex flex-col gap-1.5">
+                            <label className="text-xs font-medium text-foreground">{field.label}</label>
+                            {field.description && (
+                              <p className="text-[11px] text-muted-foreground">{field.description}</p>
+                            )}
+                            <Select value={value} onValueChange={setVal}>
+                              <SelectTrigger className="h-[30px] text-sm">
+                                <SelectValue>
+                                  {field.options.find((o) => o.value === value)?.label ?? value}
+                                </SelectValue>
+                              </SelectTrigger>
+                              <SelectContent>
+                                {field.options.map((o) => (
+                                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                        );
+                      }
+
+                      return (
+                        <div key={field.key} className="flex flex-col gap-1.5">
+                          <label className="text-xs font-medium text-foreground">{field.label}</label>
+                          {field.description && (
+                            <p className="text-[11px] text-muted-foreground">{field.description}</p>
+                          )}
+                          <input
+                            className={inputClass()}
+                            type={field.type === "password" ? "password" : "text"}
+                            placeholder={
+                              field.type === "password" && field.value === "__set__"
+                                ? "••••••••  (configured — type to replace)"
+                                : (field.placeholder ?? undefined)
+                            }
+                            value={value === "__set__" ? "" : value}
+                            onChange={(e) => setVal(e.target.value)}
+                            autoComplete={field.type === "password" ? "new-password" : undefined}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </SectionCard>
+              ))}
+              <div onClick={() => void saveExtTab(extTab.extId, extTab.tabId, allFields)}>
+                <SaveButton
+                  saving={saveExtSettingsMutation.isPending}
+                  saved={extSaved[key] ?? false}
+                />
+              </div>
+            </div>
+          );
+        })}
         </motion.div>
       </div>
 

--- a/apps/web/src/app/(panel)/servers/[id]/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/page.tsx
@@ -202,6 +202,9 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
   const [txHistory, setTxHistory] = useState<number[]>(EMPTY_HISTORY);
 
   const { data: server } = useQuery(orpc.servers.get.queryOptions({ input: { id } }));
+  const { data: extAddress } = useQuery(
+    orpc.extensions.getFieldOutput.queryOptions({ input: { entity: "server", field: "address", entityId: id } }),
+  );
 
   const [reconnectKey, setReconnectKey] = useState(0);
 
@@ -335,7 +338,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
   if (isPending || !session) return <Loader />;
 
   const alloc = server?.allocation as { ip: string; ipAlias: string | null; port: number } | null | undefined;
-  const allocDisplay = alloc ? `${alloc.ipAlias ?? alloc.ip}:${alloc.port}` : "—";
+  const allocDisplay = extAddress?.value ?? (alloc ? `${alloc.ipAlias ?? alloc.ip}:${alloc.port}` : "—");
   const canStart = wsStatus === "offline";
   const canStop = wsStatus === "running";
   const canKill = wsStatus === "starting" || wsStatus === "stopping";
@@ -492,6 +495,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
               <span className="text-xl font-bold text-foreground">{fmtBytes(txHistory[txHistory.length - 1] ?? 0)}</span>
             </StatRow>
           </div>
+          <ExtensionSlot name="server.stats.after" context={{ serverId: id }} />
         </aside>
       </div>
       <ExtensionSlot

--- a/apps/web/src/app/(panel)/servers/[id]/settings/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/settings/page.tsx
@@ -26,6 +26,7 @@ import { useTranslations } from "next-intl";
 import { orpc, queryClient } from "@/utils/orpc";
 import { authClient } from "@/lib/auth-client";
 import Loader from "@/components/loader";
+import { ExtensionSlot } from "@/components/extension-slot";
 
 function StatRow({
   icon: Icon,
@@ -227,6 +228,7 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
   const [nameStatus, setNameStatus] = useState<SaveStatus | undefined>(undefined);
   const [imageStatus, setImageStatus] = useState<SaveStatus | undefined>(undefined);
   const [varStatuses, setVarStatuses] = useState<Record<string, SaveStatus>>({});
+  const [extSettingStatuses, setExtSettingStatuses] = useState<Record<string, SaveStatus>>({});
 
   useEffect(() => {
     if (!isPending && !session) router.replace("/login");
@@ -235,6 +237,13 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
   const { data: server, isPending: serverPending } = useQuery(
     orpc.servers.get.queryOptions({ input: { id } }),
   );
+  const { data: extSftpHost } = useQuery(
+    orpc.extensions.getFieldOutput.queryOptions({ input: { entity: "server", field: "sftp.host", entityId: id } }),
+  );
+  const { data: extSettings } = useQuery(
+    orpc.extensions.getServerSettings.queryOptions({ input: { serverId: id } }),
+  );
+  const saveExtSettingMutation = useMutation(orpc.extensions.saveServerSetting.mutationOptions());
 
   const reinstallMutation = useMutation({
     ...orpc.servers.reinstall.mutationOptions(),
@@ -293,12 +302,27 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
     }
   }
 
+  async function saveExtSetting(extId: string, key: string, value: string) {
+    const statusKey = `${extId}:${key}`;
+    setExtSettingStatuses((prev) => ({ ...prev, [statusKey]: "saving" }));
+    try {
+      await saveExtSettingMutation.mutateAsync({ serverId: id, extId, key, value });
+      setExtSettingStatuses((prev) => ({ ...prev, [statusKey]: "saved" }));
+      setTimeout(
+        () => setExtSettingStatuses((prev) => { const next = { ...prev }; delete next[statusKey]; return next; }),
+        2000,
+      );
+    } catch {
+      setExtSettingStatuses((prev) => ({ ...prev, [statusKey]: "error" }));
+    }
+  }
+
   if (isPending || !session) return <Loader />;
   if (serverPending) return <Loader />;
 
   const node = server?.node as { name?: string; fqdn?: string; daemonSFTP?: number } | undefined;
   const sftp = {
-    host: node?.fqdn ?? "—",
+    host: extSftpHost?.value ?? node?.fqdn ?? "—",
     port: node?.daemonSFTP ?? 2022,
     username: `${session?.user.email?.split("@")[0] ?? "user"}.${server?.uuidShort ?? ""}`,
   };
@@ -352,6 +376,8 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
             </SettingRow>
           </SectionCard>
 
+          <ExtensionSlot name="server.settings.general.after" context={{ serverId: id }} />
+
           <SectionCard title={t("sftpTitle")} description={t("sftpDescription")}>
             <div className="grid grid-cols-1 sm:grid-cols-3">
               {[
@@ -388,6 +414,8 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
               </Button>
             </div>
           </SectionCard>
+
+          <ExtensionSlot name="server.settings.sftp.after" context={{ serverId: id }} />
 
           <SectionCard title={t("startupTitle")} description={t("startupDescription")}>
             <div className="border-b border-border px-4 py-3">
@@ -468,6 +496,43 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
             </SettingRow>
           </SectionCard>
 
+          {(extSettings ?? []).map((ext) => (
+            <SectionCard
+              key={ext.extId}
+              title={ext.extName}
+              description={t("extensionSettingsDescription")}
+            >
+              {ext.fields.map((field) => {
+                const statusKey = `${ext.extId}:${field.key}`;
+                return (
+                  <SettingRow
+                    key={field.key}
+                    label={field.label}
+                    description={field.description ?? undefined}
+                  >
+                    <div className="flex items-center gap-2">
+                      {field.type === "toggle" ? (
+                        <Toggle
+                          checked={field.value === "1"}
+                          onChange={(v) => void saveExtSetting(ext.extId, field.key, v ? "1" : "0")}
+                          disabled={extSettingStatuses[statusKey] === "saving"}
+                        />
+                      ) : (
+                        <DebouncedInput
+                          defaultValue={field.value}
+                          onSave={(v) => void saveExtSetting(ext.extId, field.key, v)}
+                          placeholder={field.placeholder ?? undefined}
+                          className="w-48 rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground outline-none focus:border-ring transition-colors"
+                        />
+                      )}
+                      <SaveIndicator status={extSettingStatuses[statusKey]} />
+                    </div>
+                  </SettingRow>
+                );
+              })}
+            </SectionCard>
+          ))}
+
           <Dialog open={reinstallConfirm} onOpenChange={(open) => { if (!open) setReinstallConfirm(false); }}>
             <DialogPopup showCloseButton={false} className="max-w-md">
               <DialogHeader>
@@ -516,6 +581,7 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
                 </button>
               </div>
             </StatRow>
+            <ExtensionSlot name="server.settings.sidebar.after" context={{ serverId: id }} />
           </div>
         </aside>
       </div>

--- a/apps/web/src/app/(panel)/servers/[id]/settings/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/settings/page.tsx
@@ -307,6 +307,7 @@ export default function SettingsPage({ params }: { params: Promise<{ id: string 
     setExtSettingStatuses((prev) => ({ ...prev, [statusKey]: "saving" }));
     try {
       await saveExtSettingMutation.mutateAsync({ serverId: id, extId, key, value });
+      void queryClient.invalidateQueries(orpc.extensions.getServerSettings.queryOptions({ input: { serverId: id } }));
       setExtSettingStatuses((prev) => ({ ...prev, [statusKey]: "saved" }));
       setTimeout(
         () => setExtSettingStatuses((prev) => { const next = { ...prev }; delete next[statusKey]; return next; }),

--- a/apps/web/src/components/extension-frame.tsx
+++ b/apps/web/src/components/extension-frame.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
+import { useMessages } from "next-intl";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
 
@@ -70,17 +71,20 @@ export function ExtensionFrame({
   const router = useRouter();
   const { resolvedTheme } = useTheme();
   const { data: session } = authClient.useSession();
+  const allMessages = useMessages() as Record<string, unknown>;
   const [height, setHeight] = useState<number>(fill ? 0 : 240);
 
   // Keep latest context in a ref so the message handler isn't re-created.
-  const ctxRef = useRef({ resolvedTheme, session, params, extId });
-  ctxRef.current = { resolvedTheme, session, params, extId };
+  const ctxRef = useRef({ resolvedTheme, session, params, extId, allMessages });
+  ctxRef.current = { resolvedTheme, session, params, extId, allMessages };
 
   function postInit() {
     const win = ref.current?.contentWindow;
     if (!win) return;
-    const { resolvedTheme: mode, session: s, params: p, extId: id } =
+    const { resolvedTheme: mode, session: s, params: p, extId: id, allMessages: msgs } =
       ctxRef.current;
+    const extMessages =
+      ((msgs.ext as Record<string, unknown> | undefined)?.[id] as Record<string, unknown>) ?? {};
     win.postMessage(
       {
         type: "struxa:host:init",
@@ -93,6 +97,7 @@ export function ExtensionFrame({
             locale: readLocale(),
           },
           params: p,
+          messages: extMessages,
         },
       },
       window.location.origin,

--- a/apps/web/src/components/extension-nav.tsx
+++ b/apps/web/src/components/extension-nav.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useMessages } from "next-intl";
 import {
   SidebarMenuButton,
   SidebarMenuItem,
@@ -33,6 +34,8 @@ export function ExtensionNav({
   routePrefix?: string;
 }) {
   const pathname = usePathname();
+  const allMessages = useMessages() as Record<string, unknown>;
+  const extMessages = allMessages.ext as Record<string, Record<string, unknown>> | undefined;
   const { data } = useQuery(
     orpc.extensions.uiPages.queryOptions({ input: { section } }),
   );
@@ -44,16 +47,17 @@ export function ExtensionNav({
       {pages.map((page) => {
         const href = `${routePrefix}${page.route}`;
         const Icon = getExtensionIcon(page.icon);
+        const resolved = (extMessages?.[page.extId]?.[page.label] as string | undefined) ?? page.label;
         return (
           <SidebarMenuItem key={`${page.extId}:${page.route}`}>
             <SidebarMenuButton
               render={<Link href={href as never} />}
               isActive={routeIsActive(pathname, href)}
-              tooltip={page.label}
+              tooltip={resolved}
               className="h-auto gap-2 rounded-lg py-2 px-3 text-sm transition-colors duration-150"
             >
               <Icon className="h-4 w-4" />
-              {page.label}
+              {resolved}
             </SidebarMenuButton>
           </SidebarMenuItem>
         );

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
         "@struxa/db": "workspace:*",
         "@struxa/env": "workspace:*",
         "@struxa/extension-host": "workspace:*",
-        "@struxa/extension-sdk": "^1.0.0",
+        "@struxa/extension-sdk": "^1.0.1",
         "@struxa/ui": "workspace:*",
         "@tanstack/react-form": "^1.28.0",
         "@tanstack/react-query": "^5.90.12",
@@ -162,7 +162,7 @@
         "@orpc/server": "catalog:",
         "@struxa/db": "workspace:*",
         "@struxa/env": "workspace:*",
-        "@struxa/extension-sdk": "^1.0.0",
+        "@struxa/extension-sdk": "^1.0.1",
         "drizzle-orm": "^0.45.1",
         "tar": "^7.4.3",
         "zod": "catalog:",
@@ -747,7 +747,7 @@
 
     "@struxa/extension-host": ["@struxa/extension-host@workspace:packages/extension-host"],
 
-    "@struxa/extension-sdk": ["@struxa/extension-sdk@1.0.0", "", { "dependencies": { "@orpc/client": "^1.13.14", "@orpc/server": "^1.13.14", "drizzle-orm": "^0.45.1", "zod": "^4.1.13" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react", "react-dom"] }, "sha512-Tjf4impRZebU1Zbkbi8EDVbiiRxODPOFKhEEdfqEtZWWJN+gDiMY34O4+tDLFWrYr9A37nSa3ZIu/i+x5lcvrg=="],
+    "@struxa/extension-sdk": ["@struxa/extension-sdk@1.0.1", "", { "dependencies": { "@orpc/client": "^1.13.14", "@orpc/server": "^1.13.14", "drizzle-orm": "^0.45.1", "zod": "^4.1.13" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react", "react-dom"] }, "sha512-FvwKoE9PL3tSy28pB6LHiXluJey2xyXSuJsufpgI+ixQ9Mb9OzMvx3Xpw2GWtzmd3t28i/K78SFJH8+Dzn/fuw=="],
 
     "@struxa/ui": ["@struxa/ui@workspace:packages/ui"],
 

--- a/packages/api/src/routers/extensions.ts
+++ b/packages/api/src/routers/extensions.ts
@@ -296,16 +296,19 @@ export const extensionsRouter = {
 
       for (const [key, value] of Object.entries(input.values)) {
         if (!declaredKeys.has(key)) continue;
-        // Skip password sentinel — means the client didn't change it
         if (value === "__set__") continue;
         changes[key] = value;
-        await db
-          .insert(settings)
-          .values({ key: ns + key, value })
-          .onDuplicateKeyUpdate({ set: { value } });
       }
 
       if (Object.keys(changes).length > 0) {
+        await db.transaction(async (tx) => {
+          for (const [key, value] of Object.entries(changes)) {
+            await tx
+              .insert(settings)
+              .values({ key: ns + key, value })
+              .onDuplicateKeyUpdate({ set: { value } });
+          }
+        });
         emitToExtension(input.extId, "admin.settings.saved", {
           tabId: input.tabId,
           changes,

--- a/packages/api/src/routers/extensions.ts
+++ b/packages/api/src/routers/extensions.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 import { ORPCError } from "@orpc/server";
-import { db, extensions } from "@struxa/db";
+import { sql, and, eq, inArray } from "drizzle-orm";
+import { db, extensions, servers, subusers, settings } from "@struxa/db";
+import { like } from "drizzle-orm";
 import {
   extensionRegistry,
+  emitToExtension,
   forgetExtensionMigrations,
   dropExtensionTables,
   installExtension,
@@ -13,7 +16,6 @@ import {
   unsubscribeExtension,
   uninstallExtensionFiles,
 } from "@struxa/extension-host";
-import { eq } from "drizzle-orm";
 
 import { adminProcedure, protectedProcedure } from "../index";
 
@@ -46,6 +48,255 @@ export const extensionsRouter = {
         widget: s.widget,
       })),
     ),
+
+  /**
+   * Read the value published by an extension for a named output field, e.g.
+   * `{ entity: "server", field: "address", entityId: "abc" }`. Returns null if
+   * no active extension has set a value for this slot.
+   *
+   * Authorization: entity access is verified before returning — callers can only
+   * read outputs for entities they already have access to.
+   */
+  getFieldOutput: protectedProcedure
+    .input(z.object({ entity: z.string(), field: z.string(), entityId: z.string() }))
+    .handler(async ({ context, input }) => {
+      const { entity, field, entityId } = input;
+      const userId = context.session.user.id;
+      const isAdmin = context.session.user.role === "admin";
+
+      if (entity === "server") {
+        const server = await db.query.servers.findFirst({
+          where: eq(servers.uuid, entityId),
+          columns: { id: true, userId: true },
+        });
+        if (!server) throw new ORPCError("NOT_FOUND");
+        if (!isAdmin && server.userId !== userId) {
+          const sub = await db.query.subusers.findFirst({
+            where: and(eq(subusers.userId, userId), eq(subusers.serverId, server.id)),
+          });
+          if (!sub) throw new ORPCError("FORBIDDEN");
+        }
+      } else {
+        // Unknown entity type — reject rather than silently leaking data
+        throw new ORPCError("NOT_FOUND");
+      }
+
+      return { value: extensionRegistry.getFieldOutput(entity, field, entityId) };
+    }),
+
+  // ---- Extension server settings ----
+
+  /**
+   * Returns all active extensions that declare `ui.serverSettings` fields and
+   * have been granted `core.metadata:server`, merged with their current stored
+   * values for the given server. Caller must have access to the server.
+   */
+  getServerSettings: protectedProcedure
+    .input(z.object({ serverId: z.string() }))
+    .handler(async ({ context, input }) => {
+      const userId = context.session.user.id;
+      const isAdmin = context.session.user.role === "admin";
+
+      const server = await db.query.servers.findFirst({
+        where: eq(servers.uuid, input.serverId),
+        columns: { id: true, userId: true, metadata: true },
+      });
+      if (!server) throw new ORPCError("NOT_FOUND");
+      if (!isAdmin && server.userId !== userId) {
+        const sub = await db.query.subusers.findFirst({
+          where: and(eq(subusers.userId, userId), eq(subusers.serverId, server.id)),
+        });
+        if (!sub) throw new ORPCError("FORBIDDEN");
+      }
+
+      const activeExts = extensionRegistry.active().filter(
+        (e) => (e.manifest.ui?.serverSettings ?? []).length > 0,
+      );
+      if (!activeExts.length) return [];
+
+      const extRows = await db.query.extensions.findMany({
+        where: inArray(extensions.id, activeExts.map((e) => e.id)),
+        columns: { id: true, grantedPermissions: true },
+      });
+      const grantMap = new Map(
+        extRows.map((r) => [r.id, (r.grantedPermissions as string[] | null) ?? []]),
+      );
+
+      const serverMeta = (server.metadata ?? {}) as Record<string, Record<string, unknown>>;
+
+      return activeExts
+        .filter((e) => grantMap.get(e.id)?.includes("core.metadata:server"))
+        .map((e) => {
+          const extMeta = serverMeta[e.id] ?? {};
+          return {
+            extId: e.id,
+            extName: e.manifest.name,
+            fields: (e.manifest.ui?.serverSettings ?? []).map((f) => ({
+              key: f.key,
+              label: f.label,
+              description: f.description ?? null,
+              type: f.type,
+              placeholder: f.placeholder ?? null,
+              value: String(extMeta[f.key] ?? ""),
+            })),
+          };
+        });
+    }),
+
+  /**
+   * Save one extension-declared server setting. Fires `server.settings.saved`
+   * to that extension's handlers only. Caller must have server access; the
+   * extension must be active with `core.metadata:server` granted and the key
+   * must be declared in its manifest.
+   */
+  saveServerSetting: protectedProcedure
+    .input(z.object({ serverId: z.string(), extId: z.string(), key: z.string(), value: z.string() }))
+    .handler(async ({ context, input }) => {
+      const userId = context.session.user.id;
+      const isAdmin = context.session.user.role === "admin";
+
+      const server = await db.query.servers.findFirst({
+        where: eq(servers.uuid, input.serverId),
+        columns: { id: true, userId: true },
+      });
+      if (!server) throw new ORPCError("NOT_FOUND");
+      if (!isAdmin && server.userId !== userId) {
+        const sub = await db.query.subusers.findFirst({
+          where: and(eq(subusers.userId, userId), eq(subusers.serverId, server.id)),
+        });
+        if (!sub) throw new ORPCError("FORBIDDEN");
+      }
+
+      const ext = extensionRegistry.get(input.extId);
+      if (!ext || ext.status !== "active") throw new ORPCError("NOT_FOUND");
+
+      const extRow = await db.query.extensions.findFirst({
+        where: eq(extensions.id, input.extId),
+        columns: { grantedPermissions: true },
+      });
+      const granted = (extRow?.grantedPermissions as string[] | null) ?? [];
+      if (!granted.includes("core.metadata:server")) throw new ORPCError("FORBIDDEN");
+
+      const declaredKeys = (ext.manifest.ui?.serverSettings ?? []).map((f) => f.key);
+      if (!declaredKeys.includes(input.key)) throw new ORPCError("NOT_FOUND");
+
+      // Write via the same atomic JSON_SET pattern used by coreMeta
+      if (!/^[a-z][a-z0-9-]{1,62}$/.test(input.extId)) throw new ORPCError("BAD_REQUEST");
+      const path = `$."${input.extId}"`;
+      const patchJson = JSON.stringify({ [input.key]: input.value });
+      await db.update(servers).set({
+        metadata: sql`JSON_SET(
+          COALESCE(${servers.metadata}, JSON_OBJECT()),
+          ${path},
+          JSON_MERGE_PATCH(
+            COALESCE(JSON_EXTRACT(${servers.metadata}, ${path}), JSON_OBJECT()),
+            CAST(${patchJson} AS JSON)
+          )
+        )`,
+      }).where(eq(servers.id, server.id));
+
+      emitToExtension(input.extId, "server.settings.saved", {
+        serverId: input.serverId,
+        key: input.key,
+        value: input.value,
+      });
+    }),
+
+  // ---- Extension admin settings tabs ----
+
+  /**
+   * All active extensions that declare `ui.adminSettingsTabs`, with current
+   * stored values merged in. Password field values are replaced with a sentinel
+   * so the browser knows one is set without receiving the raw secret.
+   */
+  getAdminSettingsTabs: adminProcedure.handler(async () => {
+    const activeExts = extensionRegistry.active().filter(
+      (e) => (e.manifest.ui?.adminSettingsTabs ?? []).length > 0,
+    );
+    if (!activeExts.length) return [];
+
+    return Promise.all(
+      activeExts.map(async (ext) => {
+        const ns = `ext:${ext.id}:`;
+        const rows = await db
+          .select()
+          .from(settings)
+          .where(like(settings.key, `${ns}%`));
+        const valMap = Object.fromEntries(
+          rows.map((r) => [r.key.slice(ns.length), r.value ?? ""]),
+        );
+
+        // Resolve tab label via extension messages (best-effort)
+        return (ext.manifest.ui?.adminSettingsTabs ?? []).map((tab) => ({
+          extId: ext.id,
+          extName: ext.manifest.name,
+          tabId: tab.id,
+          label: tab.label,
+          sections: tab.sections.map((sec) => ({
+            title: sec.title,
+            description: sec.description ?? null,
+            fields: sec.fields.map((f) => ({
+              key: f.key,
+              label: f.label,
+              description: f.description ?? null,
+              type: f.type,
+              placeholder: f.placeholder ?? null,
+              options: f.options ?? null,
+              value: f.type === "password" && valMap[f.key]
+                ? "__set__"
+                : (valMap[f.key] ?? ""),
+            })),
+          })),
+        }));
+      }),
+    ).then((nested) => nested.flat());
+  }),
+
+  /**
+   * Batch-save one extension's admin settings tab values. Fires
+   * `admin.settings.saved` only to that extension's handlers.
+   */
+  saveAdminSettings: adminProcedure
+    .input(
+      z.object({
+        extId: z.string(),
+        tabId: z.string(),
+        values: z.record(z.string(), z.string()),
+      }),
+    )
+    .handler(async ({ input }) => {
+      const ext = extensionRegistry.get(input.extId);
+      if (!ext || ext.status !== "active") throw new ORPCError("NOT_FOUND");
+
+      const tab = (ext.manifest.ui?.adminSettingsTabs ?? []).find(
+        (t) => t.id === input.tabId,
+      );
+      if (!tab) throw new ORPCError("NOT_FOUND");
+
+      const declaredKeys = new Set(
+        tab.sections.flatMap((s) => s.fields.map((f) => f.key)),
+      );
+      const ns = `ext:${input.extId}:`;
+      const changes: Record<string, string> = {};
+
+      for (const [key, value] of Object.entries(input.values)) {
+        if (!declaredKeys.has(key)) continue;
+        // Skip password sentinel — means the client didn't change it
+        if (value === "__set__") continue;
+        changes[key] = value;
+        await db
+          .insert(settings)
+          .values({ key: ns + key, value })
+          .onDuplicateKeyUpdate({ set: { value } });
+      }
+
+      if (Object.keys(changes).length > 0) {
+        emitToExtension(input.extId, "admin.settings.saved", {
+          tabId: input.tabId,
+          changes,
+        });
+      }
+    }),
 
   // ---- Admin lifecycle ----
 

--- a/packages/api/src/routers/extensions.ts
+++ b/packages/api/src/routers/extensions.ts
@@ -94,6 +94,12 @@ export const extensionsRouter = {
   getServerSettings: protectedProcedure
     .input(z.object({ serverId: z.string() }))
     .handler(async ({ context, input }) => {
+      type FieldOut = {
+        key: string; label: string; description: string | null;
+        type: string; placeholder: string | null; value: string;
+      };
+      type ExtOut = { extId: string; extName: string; fields: FieldOut[] };
+
       const userId = context.session.user.id;
       const isAdmin = context.session.user.role === "admin";
 
@@ -112,7 +118,7 @@ export const extensionsRouter = {
       const activeExts = extensionRegistry.active().filter(
         (e) => (e.manifest.ui?.serverSettings ?? []).length > 0,
       );
-      if (!activeExts.length) return [];
+      if (!activeExts.length) return [] as ExtOut[];
 
       const extRows = await db.query.extensions.findMany({
         where: inArray(extensions.id, activeExts.map((e) => e.id)),
@@ -123,24 +129,23 @@ export const extensionsRouter = {
       );
 
       const serverMeta = (server.metadata ?? {}) as Record<string, Record<string, unknown>>;
+      const result: ExtOut[] = [];
 
-      return activeExts
-        .filter((e) => grantMap.get(e.id)?.includes("core.metadata:server"))
-        .map((e) => {
-          const extMeta = serverMeta[e.id] ?? {};
-          return {
-            extId: e.id,
-            extName: e.manifest.name,
-            fields: (e.manifest.ui?.serverSettings ?? []).map((f) => ({
-              key: f.key,
-              label: f.label,
-              description: f.description ?? null,
-              type: f.type,
-              placeholder: f.placeholder ?? null,
-              value: String(extMeta[f.key] ?? ""),
-            })),
-          };
-        });
+      for (const e of activeExts) {
+        if (!grantMap.get(e.id)?.includes("core.metadata:server")) continue;
+        const extMeta = serverMeta[e.id] ?? {};
+        const fields: FieldOut[] = (e.manifest.ui?.serverSettings ?? []).map((f) => ({
+          key: f.key,
+          label: f.label,
+          description: f.description ?? null,
+          type: f.type,
+          placeholder: f.placeholder ?? null,
+          value: String(extMeta[f.key] ?? ""),
+        }));
+        result.push({ extId: e.id, extName: e.manifest.name, fields });
+      }
+
+      return result;
     }),
 
   /**

--- a/packages/api/src/routers/extensions.ts
+++ b/packages/api/src/routers/extensions.ts
@@ -210,24 +210,34 @@ export const extensionsRouter = {
    * so the browser knows one is set without receiving the raw secret.
    */
   getAdminSettingsTabs: adminProcedure.handler(async () => {
+    type FieldOut = {
+      key: string; label: string; description: string | null;
+      type: string; placeholder: string | null;
+      options: Array<{ value: string; label: string }> | null;
+      value: string;
+    };
+    type SectionOut = { title: string; description: string | null; fields: FieldOut[] };
+    type TabOut = { extId: string; extName: string; tabId: string; label: string; sections: SectionOut[] };
+
     const activeExts = extensionRegistry.active().filter(
       (e) => (e.manifest.ui?.adminSettingsTabs ?? []).length > 0,
     );
-    if (!activeExts.length) return [];
+    if (!activeExts.length) return [] as TabOut[];
 
-    return Promise.all(
-      activeExts.map(async (ext) => {
-        const ns = `ext:${ext.id}:`;
-        const rows = await db
-          .select()
-          .from(settings)
-          .where(like(settings.key, `${ns}%`));
-        const valMap = Object.fromEntries(
-          rows.map((r) => [r.key.slice(ns.length), r.value ?? ""]),
-        );
+    const result: TabOut[] = [];
 
-        // Resolve tab label via extension messages (best-effort)
-        return (ext.manifest.ui?.adminSettingsTabs ?? []).map((tab) => ({
+    for (const ext of activeExts) {
+      const ns = `ext:${ext.id}:`;
+      const rows = await db
+        .select()
+        .from(settings)
+        .where(like(settings.key, `${ns}%`));
+      const valMap = Object.fromEntries(
+        rows.map((r) => [r.key.slice(ns.length), r.value ?? ""]),
+      );
+
+      for (const tab of ext.manifest.ui?.adminSettingsTabs ?? []) {
+        result.push({
           extId: ext.id,
           extName: ext.manifest.name,
           tabId: tab.id,
@@ -242,14 +252,14 @@ export const extensionsRouter = {
               type: f.type,
               placeholder: f.placeholder ?? null,
               options: f.options ?? null,
-              value: f.type === "password" && valMap[f.key]
-                ? "__set__"
-                : (valMap[f.key] ?? ""),
+              value: f.type === "password" && valMap[f.key] ? "__set__" : (valMap[f.key] ?? ""),
             })),
           })),
-        }));
-      }),
-    ).then((nested) => nested.flat());
+        });
+      }
+    }
+
+    return result;
   }),
 
   /**

--- a/packages/extension-host/package.json
+++ b/packages/extension-host/package.json
@@ -14,7 +14,7 @@
     "@orpc/server": "catalog:",
     "@struxa/db": "workspace:*",
     "@struxa/env": "workspace:*",
-    "@struxa/extension-sdk": "^1.0.0",
+    "@struxa/extension-sdk": "^1.0.1",
     "drizzle-orm": "^0.45.1",
     "tar": "^7.4.3",
     "zod": "catalog:"

--- a/packages/extension-host/src/capabilities.ts
+++ b/packages/extension-host/src/capabilities.ts
@@ -4,6 +4,7 @@ import type {
   CoreMetaClient,
   ExtensionContext,
   ExtensionLogger,
+  FieldOutputs,
   ProcedureBuilder,
   ScopedProcedures,
   ScopedSettings,
@@ -12,6 +13,7 @@ import type { CoreMetaEntity } from "@struxa/extension-sdk";
 import { eq, like } from "drizzle-orm";
 
 import { subscribe } from "./hooks";
+import { extensionRegistry } from "./registry";
 
 /** The host's real, context-bound oRPC builders, injected by the app layer. */
 export interface HostProcedures {
@@ -151,6 +153,34 @@ export function buildContext(opts: {
       .map((p) => p.slice("hook:".length)),
   );
 
+  // Permitted output slots: set of "entity:field" pairs from output:<entity>:<field> grants.
+  const outputGrants = new Set(
+    permissions
+      .filter((p) => p.startsWith("output:"))
+      .map((p) => p.slice("output:".length)),
+  );
+
+  const fieldOutputs: FieldOutputs = {
+    set(entity, field, entityId, value) {
+      if (!outputGrants.has(`${entity}:${field}`)) {
+        console.warn(
+          `[extensions] ${extId} called fieldOutputs.set("${entity}", "${field}", ...) without output:${entity}:${field} permission; ignored`,
+        );
+        return;
+      }
+      extensionRegistry.setFieldOutput(entity, field, entityId, value, extId);
+    },
+    clear(entity, field, entityId) {
+      if (!outputGrants.has(`${entity}:${field}`)) {
+        console.warn(
+          `[extensions] ${extId} called fieldOutputs.clear("${entity}", "${field}", ...) without output:${entity}:${field} permission; ignored`,
+        );
+        return;
+      }
+      extensionRegistry.clearFieldOutput(entity, field, entityId, extId);
+    },
+  };
+
   return {
     extId,
     version,
@@ -175,5 +205,6 @@ export function buildContext(opts: {
       },
     },
     procedures: scoped,
+    fieldOutputs,
   };
 }

--- a/packages/extension-host/src/hooks.ts
+++ b/packages/extension-host/src/hooks.ts
@@ -40,14 +40,40 @@ export function unsubscribeExtension(extId: string): void {
 }
 
 /**
- * Fire an event. Returns immediately; handlers run detached. Errors are caught
- * per-handler and reported, never propagated to the caller.
+ * Fire an event to all subscribers. Returns immediately; handlers run detached.
+ * Errors are caught per-handler and reported, never propagated to the caller.
  */
 export function emit<E extends HookEvent>(
   event: E,
   payload: E extends keyof HookPayloads ? HookPayloads[E] : AnyPayload,
 ): void {
   const list = subscriptions.get(event);
+  if (!list?.length) return;
+  for (const sub of list) {
+    void (async () => {
+      try {
+        await sub.handler(payload as AnyPayload);
+      } catch (err) {
+        console.error(
+          `[extensions] hook handler failed (ext=${sub.extId}, event=${event}):`,
+          err,
+        );
+      }
+    })();
+  }
+}
+
+/**
+ * Fire an event only to a specific extension's handlers. Used when an event
+ * is scoped to one extension (e.g. its own settings being saved) so other
+ * extensions don't receive unrelated notifications.
+ */
+export function emitToExtension<E extends HookEvent>(
+  targetExtId: string,
+  event: E,
+  payload: E extends keyof HookPayloads ? HookPayloads[E] : AnyPayload,
+): void {
+  const list = subscriptions.get(event)?.filter((s) => s.extId === targetExtId);
   if (!list?.length) return;
   for (const sub of list) {
     void (async () => {

--- a/packages/extension-host/src/index.ts
+++ b/packages/extension-host/src/index.ts
@@ -25,7 +25,7 @@ export {
 } from "./catalog";
 export type { EnabledExtension } from "./catalog";
 export type { HostProcedures } from "./capabilities";
-export { emit, unsubscribeExtension } from "./hooks";
+export { emit, emitToExtension, unsubscribeExtension } from "./hooks";
 export { runExtensionMigrations, forgetExtensionMigrations, dropExtensionTables } from "./migrator";
 
 /**

--- a/packages/extension-host/src/registry.ts
+++ b/packages/extension-host/src/registry.ts
@@ -24,6 +24,8 @@ export interface RegisteredExtension {
 class ExtensionRegistry {
   private byId = new Map<string, RegisteredExtension>();
   private listeners = new Set<() => void>();
+  /** key: `"entity:field:entityId"`, value: owning extId + published value */
+  private fieldOutputMap = new Map<string, { extId: string; value: string }>();
 
   set(ext: RegisteredExtension): void {
     this.byId.set(ext.id, ext);
@@ -31,12 +33,35 @@ class ExtensionRegistry {
   }
 
   remove(id: string): void {
-    if (this.byId.delete(id)) this.emitChange();
+    if (this.byId.delete(id)) {
+      for (const [k, v] of this.fieldOutputMap) {
+        if (v.extId === id) this.fieldOutputMap.delete(k);
+      }
+      this.emitChange();
+    }
   }
 
   clear(): void {
     this.byId.clear();
+    this.fieldOutputMap.clear();
     this.emitChange();
+  }
+
+  setFieldOutput(entity: string, field: string, entityId: string, value: string, extId: string): void {
+    this.fieldOutputMap.set(`${entity}:${field}:${entityId}`, { extId, value });
+    this.emitChange();
+  }
+
+  clearFieldOutput(entity: string, field: string, entityId: string, extId: string): void {
+    const key = `${entity}:${field}:${entityId}`;
+    if (this.fieldOutputMap.get(key)?.extId === extId) {
+      this.fieldOutputMap.delete(key);
+      this.emitChange();
+    }
+  }
+
+  getFieldOutput(entity: string, field: string, entityId: string): string | null {
+    return this.fieldOutputMap.get(`${entity}:${field}:${entityId}`)?.value ?? null;
   }
 
   get(id: string): RegisteredExtension | undefined {


### PR DESCRIPTION
## Overview

Four interconnected extension system improvements that give extension developers full control over panel UI values, settings UIs, and translated strings.

---

## What's new

### 🌐 i18n for extension iframes

Extensions that ship a `messages` file now get their translated strings automatically pushed into the iframe on the bridge handshake (`struxa:host:init`). The client SDK exposes `bridge.t("key", params?)` for dot-notation key resolution with `{param}` substitution.

Host-rendered extension nav labels are also resolved through `useMessages()` now — a label can be either a literal string or an i18n key under `ext.<id>.*`.

### 🔧 Field output value providers

A new `output:<entity>:<field>` permission and `ctx.fieldOutputs` API let extensions publish computed values that replace specific host UI fields:

| Field | Where it shows |
|---|---|
| `server.address` | Address stat on the server console page |
| `server.sftp.host` | SFTP section + sidebar on the server settings page |

Values are in-memory — extensions repopulate them on boot from their own storage. The `getFieldOutput` API endpoint enforces server ownership/subuser/admin auth before returning any value.

### ⚙️ Per-server extension settings rows

Extensions can declare `ui.serverSettings` in their manifest (requires `core.metadata:server` to be granted) — the host renders a native `SectionCard` on the server settings page with text and toggle rows. Saving fires the new `server.settings.saved` hook **only to that extension**.

### 🛠️ Admin settings tabs

Extensions can declare `ui.adminSettingsTabs` to add tabs on `/admin/settings`. Tabs render natively using the same components as built-in settings (SectionCard, Toggle, Select, password inputs with set/unset detection). Values live in the global settings table under `ext:<id>:*` and are readable at runtime via `ctx.settings`. Saving fires `admin.settings.saved` **only to that extension**.

---

## New slots

| Slot | Location |
|---|---|
| `server.stats.after` | Bottom of stats sidebar, console page |
| `server.settings.general.after` | After General card, settings page |
| `server.settings.sftp.after` | After SFTP card, settings page |
| `server.settings.sidebar.after` | Bottom of sidebar, settings page |

---

## New hook events

| Event | Fired when |
|---|---|
| `server.settings.saved` | User saves a per-server extension setting |
| `admin.settings.saved` | Admin saves an extension's admin settings tab |

Both are dispatched exclusively to the owning extension via `emitToExtension()`.

---

## Security

`getFieldOutput` dispatches on `entity` before returning — unknown entity types throw `NOT_FOUND`, and `server` entities enforce the same owner/subuser/admin check used by `servers.get`. `saveServerSetting` and `saveAdminSettings` both carry equivalent auth checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782823733&installation_id=134947697&pr_number=11&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F11&signature=fd2004d455e1ca3056388be4765c104dc76f4471d5fd0a7606dea5d008e03471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensions can add dynamic admin settings tabs with draft-aware saves and per-tab save indicators.
  * Extensions can publish dynamic server field outputs (e.g., custom addresses) and inject server stats UI slots.
  * Server settings pages surface and persist extension-provided configuration fields with save UI and indicators.
  * Extension navigation and embedded extension UIs receive localized message payloads.
  * Host APIs allow extensions to publish/clear/read field outputs and target hook emissions.
  * Added English UI translation for extension settings description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->