### PR TITLE
fix(security): resolve code-scanning alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,14 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
     outputs:
       web: ${{ steps.filter.outputs.web }}
       go: ${{ steps.filter.outputs.go }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -37,6 +39,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
     outputs:
       result: ${{ job.status }}
 
@@ -45,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: useblacksmith/setup-bun@v1
+        uses: useblacksmith/setup-bun@d9a9b6b2b9986450eb588fc55d3961ecd4c81c57 # v1
         with:
           bun-version: "1.3.5"
 
@@ -60,6 +64,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
     outputs:
       result: ${{ job.status }}
 
@@ -68,7 +74,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: useblacksmith/setup-bun@v1
+        uses: useblacksmith/setup-bun@d9a9b6b2b9986450eb588fc55d3961ecd4c81c57 # v1
         with:
           bun-version: "1.3.5"
 
@@ -86,6 +92,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
     outputs:
       result: ${{ job.status }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
         run: echo "float=${{ inputs.prerelease == true && 'nightly' || 'latest' }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push dashboard
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
           file: apps/web/Dockerfile
@@ -59,7 +59,7 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
 
       - name: Build and push watchkeeper
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
           file: apps/watchkeeper/Dockerfile
@@ -69,7 +69,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.OWNER }}/watchkeeper:${{ steps.tags.outputs.float }}
 
       - name: Build and push migrate
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
           file: packages/db/Dockerfile
@@ -154,7 +154,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ inputs.version }}
           name: v${{ inputs.version }}

--- a/apps/watchkeeper/internal/wings/client.go
+++ b/apps/watchkeeper/internal/wings/client.go
@@ -15,6 +15,9 @@ type Client struct {
 }
 
 func New(scheme, fqdn string, port int, token string) *Client {
+	if scheme != "http" && scheme != "https" {
+		scheme = "https"
+	}
 	return &Client{
 		baseURL: fmt.Sprintf("%s://%s:%d", scheme, fqdn, port),
 		token:   token,

--- a/apps/watchkeeper/internal/wings/client.go
+++ b/apps/watchkeeper/internal/wings/client.go
@@ -48,7 +48,7 @@ func (c *Client) do(method, path string, body any) (*http.Response, error) {
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		resp.Body.Close()
-		return nil, fmt.Errorf("wings error %d %s", resp.StatusCode, path)
+		return nil, fmt.Errorf("wings error %d %q", resp.StatusCode, path)
 	}
 	return resp, nil
 }

--- a/apps/watchkeeper/internal/workers/schedules.go
+++ b/apps/watchkeeper/internal/workers/schedules.go
@@ -117,7 +117,7 @@ func runSchedule(db *sql.DB, sched scheduleRow) error {
 		return fmt.Errorf("mark processing: %w", err)
 	}
 
-	log.Printf("[schedules] running schedule %q for server %s", sched.name, serverUUID)
+	log.Printf("[schedules] running schedule %q for server %q", sched.name, serverUUID)
 
 	client := wings.New(nodeScheme, nodeFQDN, nodeListen, nodeToken)
 	taskErr := executeTasks(client, serverUUID, tasks)
@@ -138,7 +138,7 @@ func executeTasks(client *wings.Client, serverUUID string, tasks []taskRow) erro
 			time.Sleep(time.Duration(t.timeOffset) * time.Second)
 		}
 		if err := executeTask(client, serverUUID, t); err != nil {
-			log.Printf("[schedules] task %s (%s) failed: %v", t.id, t.action, err)
+			log.Printf("[schedules] task %q (%q) failed: %v", t.id, t.action, err)
 			if !t.continueOnFail {
 				return err
 			}

--- a/apps/web/src/app/api/remote/backups/[uuid]/restore/route.ts
+++ b/apps/web/src/app/api/remote/backups/[uuid]/restore/route.ts
@@ -26,7 +26,8 @@ export async function POST(
   const body = (await req.json()) as RestoreCompleteBody;
 
   if (!body.successful) {
-    console.error(`Backup restore failed for ${uuid} on server ${body.server_uuid}`);
+    const safeServerUUID = String(body.server_uuid).replace(/[\r\n]/g, "");
+    console.error(`Backup restore failed for ${uuid} on server ${safeServerUUID}`);
   }
 
   return new Response(null, { status: 204 });

--- a/packages/db/migrate/main.go
+++ b/packages/db/migrate/main.go
@@ -100,7 +100,7 @@ func applyMigration(db *sql.DB, dir string, entry journalEntry) error {
 	}
 	content, err := os.ReadFile(filepath.Join(dir, entry.Tag+".sql"))
 	if err != nil {
-		return fmt.Errorf("read %s.sql: %w", entry.Tag, err)
+		return fmt.Errorf("read %q.sql: %w", entry.Tag, err)
 	}
 
 	sum := sha256.Sum256(content)
@@ -119,14 +119,14 @@ func applyMigration(db *sql.DB, dir string, entry journalEntry) error {
 
 	for _, stmt := range splitStatements(string(content)) {
 		if _, err := db.Exec(stmt); err != nil {
-			return fmt.Errorf("exec statement in %s: %w", entry.Tag, err)
+			return fmt.Errorf("exec statement in %q: %w", entry.Tag, err)
 		}
 	}
 
 	_, err = db.Exec(`INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)`,
 		hash, time.Now().UnixMilli())
 	if err != nil {
-		return fmt.Errorf("record migration %s: %w", entry.Tag, err)
+		return fmt.Errorf("record migration %q: %w", entry.Tag, err)
 	}
 	return nil
 }

--- a/packages/db/migrate/main.go
+++ b/packages/db/migrate/main.go
@@ -63,7 +63,7 @@ func main() {
 	log.Println("[migrate] running migrations...")
 	for _, entry := range j.Entries {
 		if err := applyMigration(db, migrationsDir, entry); err != nil {
-			log.Fatalf("[migrate] %s failed: %v", entry.Tag, err)
+			log.Fatalf("[migrate] %q failed: %v", entry.Tag, err)
 		}
 	}
 	log.Println("[migrate] done")
@@ -95,6 +95,9 @@ func readJournal(dir string) (*journal, error) {
 }
 
 func applyMigration(db *sql.DB, dir string, entry journalEntry) error {
+	if strings.ContainsAny(entry.Tag, "/\\.") {
+		return fmt.Errorf("invalid migration tag: %q", entry.Tag)
+	}
 	content, err := os.ReadFile(filepath.Join(dir, entry.Tag+".sql"))
 	if err != nil {
 		return fmt.Errorf("read %s.sql: %w", entry.Tag, err)
@@ -108,11 +111,11 @@ func applyMigration(db *sql.DB, dir string, entry journalEntry) error {
 		return err
 	}
 	if count > 0 {
-		log.Printf("[migrate] skip %s (already applied)", entry.Tag)
+		log.Printf("[migrate] skip %q (already applied)", entry.Tag)
 		return nil
 	}
 
-	log.Printf("[migrate] applying %s", entry.Tag)
+	log.Printf("[migrate] applying %q", entry.Tag)
 
 	for _, stmt := range splitStatements(string(content)) {
 		if _, err := db.Exec(stmt); err != nil {


### PR DESCRIPTION
## Summary

Addresses all actionable GitHub code-scanning alerts. Two alerts were intentional false positives and left untouched (see below).

## What changed

### GitHub Actions
- **Pinned all third-party actions to commit SHAs** in `build.yml` and `release.yml` — prevents supply-chain attacks via tag mutation (`dorny/paths-filter`, `useblacksmith/setup-bun`, `useblacksmith/setup-docker-builder`, `docker/login-action`, `useblacksmith/build-push-action`, `softprops/action-gh-release`)
- **Added `permissions: contents: read`** to all jobs in `build.yml` that were missing an explicit permissions block (`changes`, `typecheck`, `build-web`, `build-go`)

### Log injection
- **`restore/route.ts`** — strip `\r\n` from `body.server_uuid` before writing to the error log
- **`migrate/main.go`** — switch `%s` → `%q` for `entry.Tag` in all log calls; `%q` quotes and escapes the value, preventing newline injection
- **`schedules.go`** — switch `%s` → `%q` for `sched.name`, `serverUUID`, `t.id`, and `t.action` in log calls

### Path injection
- **`migrate/main.go`** — validate `entry.Tag` contains no `/`, `\`, or `.` before it reaches `filepath.Join`, blocking path traversal via a malicious `_journal.json`

### Request forgery
- **`wings/client.go`** — validate the DB-stored node scheme is `http` or `https` before building the Wings base URL; defaults to `https` otherwise

## False positives (not fixed)

| Alert | Rule | Reason |
|-------|------|--------|
| `packages/db/src/migrate.ts:7` | `js/user-controlled-bypass` | `if (!DATABASE_URL) process.exit(1)` is an intentional env-var guard, not a security bypass |
| `packages/db/migrate/main.go:118` | `go/sql-injection` | Executing raw SQL from migration files is the tool's purpose; parameterized queries cannot be used for DDL |

## Test plan

- [ ] Verify CI passes on this branch (type-check + build)
- [ ] Confirm code-scanning alerts are resolved after the scan runs on this PR
- [ ] Check Wings integration still connects correctly (scheme validation defaults to `https` for invalid values)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785070738&installation_id=134947697&pr_number=16&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F16&signature=1730a255ee85ed1b19c8bcd36af8982a803032b0bc2e8c2736e506cda5de82c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened workflow and runtime safety by pinning third-party actions to fixed revisions.
  * Improved handling of invalid or untrusted values in URLs, migration tags, and restore logs.
* **Bug Fixes**
  * Invalid URL schemes now default to a safe HTTPS value.
  * Log output now consistently quotes identifiers, reducing ambiguity.
  * Restore error logging now strips line breaks from server IDs.
* **Chores**
  * Updated workflow permissions to explicitly allow read-only repository access for required jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->