### PR TITLE
feat(auth): two-column layout redesign + SMTP-gated password reset

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -59,6 +59,7 @@
       "submitting": "Anmelden…",
       "noAccount": "Noch kein Konto?",
       "register": "Registrieren",
+      "forgotPassword": "Passwort vergessen?",
       "signInFailed": "Anmeldung nicht möglich."
     },
     "register": {
@@ -148,10 +149,40 @@
         "description": "Bei der Anmeldung ist ein Fehler aufgetreten. Bitte starten Sie den Vorgang erneut."
       }
     },
+    "forgotPassword": {
+      "title": "Passwort vergessen?",
+      "subtitle": "Gib deine E-Mail-Adresse ein und wir senden dir einen Reset-Link.",
+      "emailLabel": "E-Mail",
+      "emailPlaceholder": "du@beispiel.de",
+      "emailRequired": "E-Mail-Adresse ist erforderlich.",
+      "emailInvalid": "Gib eine gültige E-Mail-Adresse ein.",
+      "submit": "Reset-Link senden",
+      "submitting": "Senden…",
+      "successTitle": "Prüfe deinen Posteingang",
+      "successMessage": "Falls diese E-Mail registriert ist, ist ein Reset-Link unterwegs.",
+      "backToLogin": "Zurück zur Anmeldung",
+      "requestFailed": "Reset-Link konnte nicht gesendet werden."
+    },
+    "resetPassword": {
+      "title": "Neues Passwort festlegen",
+      "subtitle": "Wähle ein sicheres Passwort für dein Konto.",
+      "passwordLabel": "Neues Passwort",
+      "passwordPlaceholder": "Neues Passwort erstellen",
+      "confirmLabel": "Passwort bestätigen",
+      "confirmPlaceholder": "Passwort wiederholen",
+      "passwordMinLength": "Das Passwort muss mindestens 8 Zeichen lang sein.",
+      "passwordsNoMatch": "Die Passwörter stimmen nicht überein.",
+      "submit": "Passwort zurücksetzen",
+      "submitting": "Speichern…",
+      "invalidToken": "Dieser Reset-Link ist ungültig oder abgelaufen.",
+      "resetFailed": "Passwort konnte nicht zurückgesetzt werden.",
+      "backToLogin": "Zurück zur Anmeldung"
+    },
     "social": {
       "continueWith": "Weiter mit {provider}",
       "redirecting": "Weiterleitung…",
-      "or": "oder"
+      "or": "oder",
+      "tagline": "Spielserver bereitstellen, überwachen und verwalten — alles an einem Ort."
     }
   },
   "nav": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -59,6 +59,7 @@
       "submitting": "Signing in…",
       "noAccount": "No account yet?",
       "register": "Register",
+      "forgotPassword": "Forgot password?",
       "signInFailed": "Unable to sign in."
     },
     "register": {
@@ -148,10 +149,40 @@
         "description": "Something went wrong during sign-in. Please start the process again."
       }
     },
+    "forgotPassword": {
+      "title": "Forgot your password?",
+      "subtitle": "Enter your email and we'll send you a reset link.",
+      "emailLabel": "Email",
+      "emailPlaceholder": "you@example.com",
+      "emailRequired": "Email is required.",
+      "emailInvalid": "Enter a valid email address.",
+      "submit": "Send reset link",
+      "submitting": "Sending…",
+      "successTitle": "Check your inbox",
+      "successMessage": "If that email is registered, a reset link is on its way.",
+      "backToLogin": "Back to sign in",
+      "requestFailed": "Unable to send reset link."
+    },
+    "resetPassword": {
+      "title": "Set a new password",
+      "subtitle": "Choose a strong password for your account.",
+      "passwordLabel": "New password",
+      "passwordPlaceholder": "Create a new password",
+      "confirmLabel": "Confirm password",
+      "confirmPlaceholder": "Repeat your password",
+      "passwordMinLength": "Password must be at least 8 characters.",
+      "passwordsNoMatch": "Passwords do not match.",
+      "submit": "Reset password",
+      "submitting": "Saving…",
+      "invalidToken": "This reset link is invalid or has expired.",
+      "resetFailed": "Unable to reset password.",
+      "backToLogin": "Back to sign in"
+    },
     "social": {
       "continueWith": "Continue with {provider}",
       "redirecting": "Redirecting…",
-      "or": "or"
+      "or": "or",
+      "tagline": "Deploy, monitor, and manage your game servers from one place."
     }
   },
   "nav": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -59,6 +59,7 @@
       "submitting": "Iniciando sesión…",
       "noAccount": "¿Aún no tienes cuenta?",
       "register": "Registro",
+      "forgotPassword": "¿Olvidaste tu contraseña?",
       "signInFailed": "No se puede iniciar sesión."
     },
     "register": {
@@ -148,10 +149,40 @@
         "description": "Algo salió mal durante el inicio de sesión. Por favor inicie el proceso nuevamente."
       }
     },
+    "forgotPassword": {
+      "title": "¿Olvidaste tu contraseña?",
+      "subtitle": "Ingresa tu correo y te enviaremos un enlace para restablecer tu contraseña.",
+      "emailLabel": "Correo electrónico",
+      "emailPlaceholder": "tu@ejemplo.com",
+      "emailRequired": "El correo electrónico es obligatorio.",
+      "emailInvalid": "Ingresa una dirección de correo válida.",
+      "submit": "Enviar enlace de restablecimiento",
+      "submitting": "Enviando…",
+      "successTitle": "Revisa tu bandeja de entrada",
+      "successMessage": "Si ese correo está registrado, el enlace ya está en camino.",
+      "backToLogin": "Volver al inicio de sesión",
+      "requestFailed": "No se pudo enviar el enlace de restablecimiento."
+    },
+    "resetPassword": {
+      "title": "Establecer nueva contraseña",
+      "subtitle": "Elige una contraseña segura para tu cuenta.",
+      "passwordLabel": "Nueva contraseña",
+      "passwordPlaceholder": "Crea una nueva contraseña",
+      "confirmLabel": "Confirmar contraseña",
+      "confirmPlaceholder": "Repite tu contraseña",
+      "passwordMinLength": "La contraseña debe tener al menos 8 caracteres.",
+      "passwordsNoMatch": "Las contraseñas no coinciden.",
+      "submit": "Restablecer contraseña",
+      "submitting": "Guardando…",
+      "invalidToken": "Este enlace de restablecimiento es inválido o ha expirado.",
+      "resetFailed": "No se pudo restablecer la contraseña.",
+      "backToLogin": "Volver al inicio de sesión"
+    },
     "social": {
       "continueWith": "Continuar con {provider}",
       "redirecting": "Redirigiendo…",
-      "or": "o"
+      "or": "o",
+      "tagline": "Despliega, monitorea y administra tus servidores de juego desde un solo lugar."
     }
   },
   "nav": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -59,6 +59,7 @@
       "submitting": "Connexion…",
       "noAccount": "Pas encore de compte ?",
       "register": "Registre",
+      "forgotPassword": "Mot de passe oublié ?",
       "signInFailed": "Impossible de se connecter."
     },
     "register": {
@@ -148,10 +149,40 @@
         "description": "Une erreur s'est produite lors de la connexion. Veuillez recommencer le processus."
       }
     },
+    "forgotPassword": {
+      "title": "Mot de passe oublié ?",
+      "subtitle": "Entrez votre adresse e-mail et nous vous enverrons un lien de réinitialisation.",
+      "emailLabel": "E-mail",
+      "emailPlaceholder": "vous@exemple.fr",
+      "emailRequired": "L'adresse e-mail est requise.",
+      "emailInvalid": "Entrez une adresse e-mail valide.",
+      "submit": "Envoyer le lien de réinitialisation",
+      "submitting": "Envoi…",
+      "successTitle": "Vérifiez votre boîte de réception",
+      "successMessage": "Si cet e-mail est enregistré, un lien de réinitialisation est en route.",
+      "backToLogin": "Retour à la connexion",
+      "requestFailed": "Impossible d'envoyer le lien de réinitialisation."
+    },
+    "resetPassword": {
+      "title": "Définir un nouveau mot de passe",
+      "subtitle": "Choisissez un mot de passe fort pour votre compte.",
+      "passwordLabel": "Nouveau mot de passe",
+      "passwordPlaceholder": "Créez un nouveau mot de passe",
+      "confirmLabel": "Confirmer le mot de passe",
+      "confirmPlaceholder": "Répétez votre mot de passe",
+      "passwordMinLength": "Le mot de passe doit comporter au moins 8 caractères.",
+      "passwordsNoMatch": "Les mots de passe ne correspondent pas.",
+      "submit": "Réinitialiser le mot de passe",
+      "submitting": "Enregistrement…",
+      "invalidToken": "Ce lien de réinitialisation est invalide ou a expiré.",
+      "resetFailed": "Impossible de réinitialiser le mot de passe.",
+      "backToLogin": "Retour à la connexion"
+    },
     "social": {
       "continueWith": "Continuez avec {provider}",
       "redirecting": "Redirection…",
-      "or": "ou"
+      "or": "ou",
+      "tagline": "Déployez, surveillez et gérez vos serveurs de jeu depuis un seul endroit."
     }
   },
   "nav": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -59,6 +59,7 @@
       "submitting": "Logowanie…",
       "noAccount": "Nie masz jeszcze konta?",
       "register": "Rejestr",
+      "forgotPassword": "Nie pamiętasz hasła?",
       "signInFailed": "Nie można się zalogować."
     },
     "register": {
@@ -148,10 +149,40 @@
         "description": "Coś poszło nie tak podczas logowania. Rozpocznij proces ponownie."
       }
     },
+    "forgotPassword": {
+      "title": "Nie pamiętasz hasła?",
+      "subtitle": "Wpisz swój adres e-mail, a wyślemy Ci link do resetowania hasła.",
+      "emailLabel": "E-mail",
+      "emailPlaceholder": "ty@example.com",
+      "emailRequired": "Adres e-mail jest wymagany.",
+      "emailInvalid": "Wpisz prawidłowy adres e-mail.",
+      "submit": "Wyślij link do resetowania",
+      "submitting": "Wysyłanie…",
+      "successTitle": "Sprawdź swoją skrzynkę",
+      "successMessage": "Jeśli ten adres e-mail jest zarejestrowany, link do resetowania jest już w drodze.",
+      "backToLogin": "Wróć do logowania",
+      "requestFailed": "Nie można wysłać linku do resetowania."
+    },
+    "resetPassword": {
+      "title": "Ustaw nowe hasło",
+      "subtitle": "Wybierz silne hasło dla swojego konta.",
+      "passwordLabel": "Nowe hasło",
+      "passwordPlaceholder": "Utwórz nowe hasło",
+      "confirmLabel": "Potwierdź hasło",
+      "confirmPlaceholder": "Powtórz hasło",
+      "passwordMinLength": "Hasło musi mieć co najmniej 8 znaków.",
+      "passwordsNoMatch": "Hasła nie są zgodne.",
+      "submit": "Resetuj hasło",
+      "submitting": "Zapisywanie…",
+      "invalidToken": "Ten link do resetowania jest nieprawidłowy lub wygasł.",
+      "resetFailed": "Nie można zresetować hasła.",
+      "backToLogin": "Wróć do logowania"
+    },
     "social": {
       "continueWith": "Kontynuuj z {provider}",
       "redirecting": "Przekierowywanie…",
-      "or": "Lub"
+      "or": "Lub",
+      "tagline": "Wdrażaj, monitoruj i zarządzaj serwerami gier z jednego miejsca."
     }
   },
   "nav": {

--- a/apps/web/src/app/(auth)/2fa/page.tsx
+++ b/apps/web/src/app/(auth)/2fa/page.tsx
@@ -1,17 +1,22 @@
 "use client";
 
+import type * as React from "react";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { authClient } from "@/lib/auth-client";
+
+import { Button } from "@struxa/ui/components/button";
+import { Input } from "@struxa/ui/components/input";
+import { Label } from "@struxa/ui/components/label";
+
 import AuthShell from "@/components/auth-shell";
-import { AuthSettingsProvider } from "@/components/auth-settings-context";
-import { useAuthSettings } from "@/components/auth-settings-context";
+import { AuthSettingsProvider, useAuthSettings } from "@/components/auth-settings-context";
+import { authClient } from "@/lib/auth-client";
 
 export default function TwoFactorPage() {
   const { appName, logoUrl } = useAuthSettings();
   return (
-    <AuthSettingsProvider value={{ appName, logoUrl, socialProviders: [] }}>
+    <AuthSettingsProvider value={{ appName, logoUrl, socialProviders: [], smtpEnabled: false }}>
       <TwoFactorForm />
     </AuthSettingsProvider>
   );
@@ -56,6 +61,8 @@ function TwoFactorForm() {
     setError("");
   }
 
+  const isVerifyDisabled = pending || (!isBackupMode && code.length < 6) || (isBackupMode && !code.trim());
+
   return (
     <AuthShell
       title={t("title")}
@@ -63,31 +70,35 @@ function TwoFactorForm() {
     >
       <div className="flex flex-col gap-3.5">
         <div className="flex flex-col gap-2">
-          <label className="text-xs font-medium text-foreground">
+          <Label htmlFor="2fa-code">
             {isBackupMode ? t("backupCodeLabel") : t("codeLabel")}
-          </label>
-          <input
+          </Label>
+          <Input
+            id="2fa-code"
             autoFocus
             autoComplete="one-time-code"
             inputMode={isBackupMode ? "text" : "numeric"}
-            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-center font-mono text-sm tracking-widest text-foreground outline-none placeholder:text-muted-foreground/50 focus:border-ring transition-colors"
+            className="text-center font-mono tracking-widest"
             placeholder={isBackupMode ? t("backupCodePlaceholder") : t("codePlaceholder")}
             value={code}
             onChange={handleChange}
             onKeyDown={(e) => { if (e.key === "Enter") void handleVerify(code); }}
             disabled={pending}
+            aria-invalid={error ? true : undefined}
           />
-          {error && <p className="text-xs text-destructive">{error}</p>}
+          {error ? (
+            <p className="flex items-center gap-1 text-xs text-destructive">
+              <svg className="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm-.75 3.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zm.75 6.5a.875.875 0 1 1 0-1.75.875.875 0 0 1 0 1.75z" />
+              </svg>
+              {error}
+            </p>
+          ) : null}
         </div>
 
-        <button
-          type="button"
-          disabled={pending || (!isBackupMode && code.length < 6) || (isBackupMode && !code.trim())}
-          onClick={() => void handleVerify(code)}
-          className="w-full rounded-lg bg-foreground py-2 text-sm font-medium text-background transition-opacity hover:opacity-80 disabled:opacity-40"
-        >
+        <Button type="button" disabled={isVerifyDisabled} onClick={() => void handleVerify(code)} className="w-full">
           {pending ? t("verifying") : t("verify")}
-        </button>
+        </Button>
 
         <button
           type="button"

--- a/apps/web/src/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/apps/web/src/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type * as React from "react";
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@struxa/ui/components/button";
+import { Input } from "@struxa/ui/components/input";
+import { Label } from "@struxa/ui/components/label";
+
+import AuthShell from "@/components/auth-shell";
+import { authClient } from "@/lib/auth-client";
+
+const emailPattern = /\S+@\S+\.\S+/;
+
+function FieldError({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="flex items-center gap-1 text-xs text-destructive">
+      <svg className="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm-.75 3.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zm.75 6.5a.875.875 0 1 1 0-1.75.875.875 0 0 1 0 1.75z" />
+      </svg>
+      {children}
+    </p>
+  );
+}
+
+export default function ForgotPasswordForm() {
+  const t = useTranslations("auth.forgotPassword");
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [touchedEmail, setTouchedEmail] = useState(false);
+
+  const normalizedEmail = email.trim();
+  const emailError = !normalizedEmail
+    ? t("emailRequired")
+    : emailPattern.test(normalizedEmail)
+      ? null
+      : t("emailInvalid");
+  const showEmailError = Boolean(emailError && (hasSubmitted || touchedEmail));
+  const isDisabled = Boolean(isSubmitting);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setHasSubmitted(true);
+    setError(null);
+    if (emailError) return;
+    setIsSubmitting(true);
+    const { error: reqError } = await authClient.requestPasswordReset({
+      email: normalizedEmail,
+      redirectTo: "/reset-password",
+    });
+    setIsSubmitting(false);
+    if (reqError) {
+      setError(reqError.message ?? t("requestFailed"));
+      return;
+    }
+    setSent(true);
+  };
+
+  return (
+    <AuthShell title={t("title")} subtitle={t("subtitle")}>
+      {sent ? (
+        <div className="flex flex-col gap-3 text-center">
+          <p className="text-sm font-medium text-foreground">{t("successTitle")}</p>
+          <p className="text-sm text-muted-foreground">{t("successMessage")}</p>
+          <a
+            className="text-sm font-medium text-foreground transition-colors hover:text-foreground/80"
+            href="/login"
+          >
+            {t("backToLogin")}
+          </a>
+        </div>
+      ) : (
+        <>
+          <form className="space-y-3.5" onSubmit={handleSubmit}>
+            <div className="grid gap-2">
+              <Label htmlFor="email">{t("emailLabel")}</Label>
+              <Input
+                aria-invalid={showEmailError || undefined}
+                id="email"
+                name="email"
+                onChange={(event) => setEmail(event.target.value)}
+                onBlur={() => setTouchedEmail(true)}
+                placeholder={t("emailPlaceholder")}
+                type="email"
+                value={email}
+              />
+              {showEmailError ? <FieldError>{emailError}</FieldError> : null}
+            </div>
+            <Button className="w-full" type="submit" disabled={isDisabled}>
+              {isSubmitting ? t("submitting") : t("submit")}
+            </Button>
+            {error ? <FieldError>{error}</FieldError> : null}
+          </form>
+
+          <p className="text-center text-sm text-muted-foreground">
+            <a
+              className="font-medium text-foreground transition-colors hover:text-foreground/80"
+              href="/login"
+            >
+              {t("backToLogin")}
+            </a>
+          </p>
+        </>
+      )}
+    </AuthShell>
+  );
+}

--- a/apps/web/src/app/(auth)/forgot-password/page.tsx
+++ b/apps/web/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+import { getInstanceSettings } from "@/lib/instance-settings";
+import ForgotPasswordForm from "./forgot-password-form";
+
+export default async function ForgotPasswordPage() {
+  const { raw } = await getInstanceSettings();
+  if (raw.smtp_enabled !== "true" || !raw.smtp_host) redirect("/login");
+  return <ForgotPasswordForm />;
+}

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -7,10 +7,11 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
   const complete = await checkSetupComplete();
   if (!complete) redirect("/setup");
 
-  const { appName, logoUrl, socialProviders } = await getInstanceSettings();
+  const { appName, logoUrl, socialProviders, raw } = await getInstanceSettings();
+  const smtpEnabled = raw.smtp_enabled === "true" && !!raw.smtp_host;
 
   return (
-    <AuthSettingsProvider value={{ appName, logoUrl, socialProviders }}>
+    <AuthSettingsProvider value={{ appName, logoUrl, socialProviders, smtpEnabled }}>
       {children}
     </AuthSettingsProvider>
   );

--- a/apps/web/src/app/(auth)/register/register-form.tsx
+++ b/apps/web/src/app/(auth)/register/register-form.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import type * as React from "react";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@struxa/ui/components/button";
-import { Alert, AlertDescription } from "@struxa/ui/components/alert";
 import { Input } from "@struxa/ui/components/input";
 import { Label } from "@struxa/ui/components/label";
 
@@ -14,6 +14,17 @@ import { authClient } from "@/lib/auth-client";
 import { syncLocaleFromDB } from "@/lib/sync-locale";
 
 const emailPattern = /\S+@\S+\.\S+/;
+
+function FieldError({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="flex items-center gap-1 text-xs text-destructive">
+      <svg className="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm-.75 3.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zm.75 6.5a.875.875 0 1 1 0-1.75.875.875 0 0 1 0 1.75z" />
+      </svg>
+      {children}
+    </p>
+  );
+}
 
 export default function RegisterPage() {
   const t = useTranslations("auth.register");
@@ -71,13 +82,8 @@ export default function RegisterPage() {
   };
 
   return (
-    <AuthShell title={t("title")} subtitle={t("subtitle")}>
+    <AuthShell title={t("title")} subtitle={t("subtitle")} reverse>
       <form className="space-y-3.5" onSubmit={handleSubmit}>
-        {error ? (
-          <Alert variant="error">
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        ) : null}
         <div className="grid gap-2">
           <Label htmlFor="displayName">{t("displayNameLabel")}</Label>
           <Input
@@ -101,7 +107,7 @@ export default function RegisterPage() {
             type="email"
             value={email}
           />
-          {showEmailError ? <p className="text-xs text-rose-500">{emailError}</p> : null}
+          {showEmailError ? <FieldError>{emailError}</FieldError> : null}
         </div>
         <div className="grid gap-2">
           <Label htmlFor="password">{t("passwordLabel")}</Label>
@@ -115,11 +121,12 @@ export default function RegisterPage() {
             type="password"
             value={password}
           />
-          {showPasswordError ? <p className="text-xs text-rose-500">{passwordError}</p> : null}
+          {showPasswordError ? <FieldError>{passwordError}</FieldError> : null}
         </div>
         <Button className="w-full" type="submit" disabled={isDisabled}>
           {isSubmitting ? t("submitting") : t("submit")}
         </Button>
+        {error ? <FieldError>{error}</FieldError> : null}
       </form>
 
       <p className="text-center text-sm text-muted-foreground">

--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+import { getInstanceSettings } from "@/lib/instance-settings";
+import ResetPasswordForm from "./reset-password-form";
+
+export default async function ResetPasswordPage() {
+  const { raw } = await getInstanceSettings();
+  if (raw.smtp_enabled !== "true" || !raw.smtp_host) redirect("/login");
+  return <ResetPasswordForm />;
+}

--- a/apps/web/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/apps/web/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -2,7 +2,7 @@
 
 import type * as React from "react";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@struxa/ui/components/button";
@@ -10,11 +10,7 @@ import { Input } from "@struxa/ui/components/input";
 import { Label } from "@struxa/ui/components/label";
 
 import AuthShell from "@/components/auth-shell";
-import { useAuthSettings } from "@/components/auth-settings-context";
 import { authClient } from "@/lib/auth-client";
-import { syncLocaleFromDB } from "@/lib/sync-locale";
-
-const emailPattern = /\S+@\S+\.\S+/;
 
 function FieldError({ children }: { children: React.ReactNode }) {
   return (
@@ -27,80 +23,65 @@ function FieldError({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function LoginPage() {
-  const t = useTranslations("auth.login");
+export default function ResetPasswordForm() {
+  const t = useTranslations("auth.resetPassword");
   const router = useRouter();
-  const { smtpEnabled } = useAuthSettings();
-  const [email, setEmail] = useState("");
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
   const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false);
-  const [touchedEmail, setTouchedEmail] = useState(false);
   const [touchedPassword, setTouchedPassword] = useState(false);
+  const [touchedConfirm, setTouchedConfirm] = useState(false);
 
-  const normalizedEmail = email.trim();
-  const emailError = !normalizedEmail
-    ? t("emailRequired")
-    : emailPattern.test(normalizedEmail)
-      ? null
-      : t("emailInvalid");
   const passwordError = password.length >= 8 ? null : t("passwordMinLength");
-  const showEmailError = Boolean(emailError && (hasSubmitted || touchedEmail));
+  const confirmError = password === confirm ? null : t("passwordsNoMatch");
   const showPasswordError = Boolean(passwordError && (hasSubmitted || touchedPassword));
-  const isDisabled = Boolean(emailError || passwordError || isSubmitting);
+  const showConfirmError = Boolean(confirmError && (hasSubmitted || touchedConfirm));
+  const isDisabled = Boolean(isSubmitting);
+
+  if (!token) {
+    return (
+      <AuthShell title={t("title")} subtitle={t("subtitle")}>
+        <div className="flex flex-col gap-3 text-center">
+          <FieldError>{t("invalidToken")}</FieldError>
+          <a
+            className="text-sm font-medium text-foreground transition-colors hover:text-foreground/80"
+            href="/forgot-password"
+          >
+            {t("backToLogin")}
+          </a>
+        </div>
+      </AuthShell>
+    );
+  }
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setHasSubmitted(true);
     setError(null);
-    if (emailError || passwordError) {
-      setError(t("fixHighlighted"));
-      return;
-    }
+    if (passwordError || confirmError) return;
     setIsSubmitting(true);
-    const { error: signInError } = await authClient.signIn.email({
-      email: normalizedEmail,
-      password,
+    const { error: resetError } = await authClient.resetPassword({
+      newPassword: password,
+      token,
     });
     setIsSubmitting(false);
-    if (signInError) {
-      setError(signInError.message ?? t("signInFailed"));
+    if (resetError) {
+      setError(resetError.message ?? t("resetFailed"));
       return;
     }
-    await syncLocaleFromDB();
-    router.push("/");
+    router.push("/login");
   };
 
   return (
     <AuthShell title={t("title")} subtitle={t("subtitle")}>
       <form className="space-y-3.5" onSubmit={handleSubmit}>
         <div className="grid gap-2">
-          <Label htmlFor="email">{t("emailLabel")}</Label>
-          <Input
-            aria-invalid={showEmailError || undefined}
-            id="email"
-            name="email"
-            onChange={(event) => setEmail(event.target.value)}
-            onBlur={() => setTouchedEmail(true)}
-            placeholder={t("emailPlaceholder")}
-            type="email"
-            value={email}
-          />
-          {showEmailError ? <FieldError>{emailError}</FieldError> : null}
-        </div>
-        <div className="grid gap-2">
-          <div className="flex items-center justify-between">
-            <Label htmlFor="password">{t("passwordLabel")}</Label>
-            {smtpEnabled ? (
-              <a
-                className="text-xs text-muted-foreground transition-colors hover:text-foreground"
-                href="/forgot-password"
-              >
-                {t("forgotPassword")}
-              </a>
-            ) : null}
-          </div>
+          <Label htmlFor="password">{t("passwordLabel")}</Label>
           <Input
             aria-invalid={showPasswordError || undefined}
             id="password"
@@ -113,6 +94,20 @@ export default function LoginPage() {
           />
           {showPasswordError ? <FieldError>{passwordError}</FieldError> : null}
         </div>
+        <div className="grid gap-2">
+          <Label htmlFor="confirm">{t("confirmLabel")}</Label>
+          <Input
+            aria-invalid={showConfirmError || undefined}
+            id="confirm"
+            name="confirm"
+            onChange={(event) => setConfirm(event.target.value)}
+            onBlur={() => setTouchedConfirm(true)}
+            placeholder={t("confirmPlaceholder")}
+            type="password"
+            value={confirm}
+          />
+          {showConfirmError ? <FieldError>{confirmError}</FieldError> : null}
+        </div>
         <Button className="w-full" type="submit" disabled={isDisabled}>
           {isSubmitting ? t("submitting") : t("submit")}
         </Button>
@@ -120,12 +115,11 @@ export default function LoginPage() {
       </form>
 
       <p className="text-center text-sm text-muted-foreground">
-        {t("noAccount")}{" "}
         <a
           className="font-medium text-foreground transition-colors hover:text-foreground/80"
-          href="/register"
+          href="/login"
         >
-          {t("register")}
+          {t("backToLogin")}
         </a>
       </p>
     </AuthShell>

--- a/apps/web/src/components/auth-settings-context.tsx
+++ b/apps/web/src/components/auth-settings-context.tsx
@@ -6,9 +6,10 @@ type AuthSettings = {
   appName: string;
   logoUrl: string | null;
   socialProviders: string[];
+  smtpEnabled: boolean;
 };
 
-const AuthSettingsContext = createContext<AuthSettings>({ appName: "Struxa", logoUrl: null, socialProviders: [] });
+const AuthSettingsContext = createContext<AuthSettings>({ appName: "Struxa", logoUrl: null, socialProviders: [], smtpEnabled: false });
 
 export function AuthSettingsProvider({ value, children }: { value: AuthSettings; children: React.ReactNode }) {
   return <AuthSettingsContext value={value}>{children}</AuthSettingsContext>;

--- a/apps/web/src/components/auth-shell.tsx
+++ b/apps/web/src/components/auth-shell.tsx
@@ -11,6 +11,7 @@ type AuthShellProps = {
   title: string;
   subtitle: string;
   children: React.ReactNode;
+  reverse?: boolean;
 };
 
 function GithubIcon({ className }: { className?: string }) {
@@ -34,7 +35,20 @@ const PROVIDER_META: Record<string, { label: string; icon: React.FC<{ className?
   discord: { label: "Discord", icon: DiscordIcon, color: "hover:bg-[#5865F2] hover:text-white hover:border-[#5865F2]" },
 };
 
-export default function AuthShell({ title, subtitle, children }: AuthShellProps) {
+function Logo({ logoUrl, appName, className }: { logoUrl: string | null; appName: string; className?: string }) {
+  if (logoUrl) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={logoUrl} alt={appName} className={className ?? "h-7 w-auto"} />;
+  }
+  return (
+    <>
+      <Image src="/logo-dark.svg" alt="Struxa" width={96} height={28} priority className={`w-auto dark:hidden ${className ?? "h-7"}`} />
+      <Image src="/logo-white.svg" alt="Struxa" width={96} height={28} priority className={`hidden w-auto dark:block ${className ?? "h-7"}`} />
+    </>
+  );
+}
+
+export default function AuthShell({ title, subtitle, children, reverse }: AuthShellProps) {
   const t = useTranslations("auth.social");
   const { appName, logoUrl, socialProviders } = useAuthSettings();
   const [loadingProvider, setLoadingProvider] = useState<string | null>(null);
@@ -49,26 +63,33 @@ export default function AuthShell({ title, subtitle, children }: AuthShellProps)
   }
 
   return (
-    <main className="min-h-svh bg-background">
-      <div className="mx-auto flex min-h-svh max-w-xl items-center justify-center px-4 py-8">
-        <div className="flex w-full max-w-sm flex-col items-center gap-6">
-          <div className="flex flex-col items-center gap-2 text-center">
-            <div className="mb-1">
-              {logoUrl ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={logoUrl} alt={appName} className="h-7 w-auto" />
-              ) : (
-                <>
-                  <Image src="/logo-dark.svg" alt="Struxa" width={96} height={28} priority className="h-7 w-auto dark:hidden" />
-                  <Image src="/logo-white.svg" alt="Struxa" width={96} height={28} priority className="hidden h-7 w-auto dark:block" />
-                </>
-              )}
-            </div>
-            <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
+    <main className="min-h-svh bg-background lg:grid lg:grid-cols-2">
+      {/* Branding panel — desktop only */}
+      <div className={`relative hidden lg:flex lg:flex-col lg:justify-between bg-muted/40 border-border px-12 py-10 ${reverse ? "lg:order-2 lg:items-end border-l" : "lg:order-1 lg:items-start border-r"}`}>
+        <Logo logoUrl={logoUrl} appName={appName} className="h-7" />
+        <div className={`flex flex-col gap-2 ${reverse ? "items-end text-right" : "items-start text-left"}`}>
+          <p className="text-2xl font-semibold tracking-tight text-foreground">{appName}</p>
+          <p className="text-sm text-muted-foreground max-w-xs">
+            {t("tagline")}
+          </p>
+        </div>
+        <p className="text-xs text-muted-foreground/60">© {new Date().getFullYear()} Struxa</p>
+      </div>
+
+      {/* Form panel */}
+      <div className={`flex min-h-svh flex-col items-center justify-center px-4 py-10 lg:min-h-0 lg:py-16 ${reverse ? "lg:order-1" : "lg:order-2"}`}>
+        <div className="flex w-full max-w-sm flex-col gap-6">
+          {/* Logo shown only on mobile */}
+          <div className="flex justify-center lg:hidden">
+            <Logo logoUrl={logoUrl} appName={appName} className="h-7" />
+          </div>
+
+          <div className="flex flex-col gap-1 text-center">
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">{title}</h1>
             <p className="text-sm text-muted-foreground">{subtitle}</p>
           </div>
 
-          <div className="flex w-full flex-col gap-4 rounded-2xl border bg-card p-6 shadow-sm">
+          <div className="flex flex-col gap-4">
             {socialProviders.length > 0 && (
               <>
                 <div className="flex flex-col gap-2">

--- a/bun.lock
+++ b/bun.lock
@@ -109,6 +109,7 @@
       "name": "@struxa/auth",
       "dependencies": {
         "@better-auth/api-key": "catalog:",
+        "@better-auth/i18n": "catalog:",
         "@struxa/db": "workspace:*",
         "@struxa/env": "workspace:*",
         "@types/nodemailer": "^8.0.0",
@@ -195,6 +196,7 @@
   },
   "catalog": {
     "@better-auth/api-key": "1.6.9",
+    "@better-auth/i18n": "1.6.9",
     "@orpc/client": "^1.13.14",
     "@orpc/openapi": "^1.13.14",
     "@orpc/server": "^1.13.14",
@@ -343,6 +345,8 @@
     "@better-auth/core": ["@better-auth/core@1.6.9", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w=="],
 
     "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw=="],
+
+    "@better-auth/i18n": ["@better-auth/i18n@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "better-auth": "^1.6.9" } }, "sha512-/7R6YkWoQmUk9DXhtbGkZoxGkV7bZbsxU8q3JlSDntkB1oqA3JOSIX7fl8kikCj5ppj6Ffj2F6eVTXYA6PolzQ=="],
 
     "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "kysely": "^0.28.14" }, "optionalPeers": ["kysely"] }, "sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
       "@orpc/zod": "^1.13.14",
       "better-auth": "1.6.9",
       "@better-auth/api-key": "1.6.9",
+      "@better-auth/i18n": "1.6.9",
       "jose": "^5.10.0",
       "croner": "^9.0.0",
       "@types/react": "^19.2.10",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,6 +12,7 @@
   "scripts": {},
   "dependencies": {
     "@better-auth/api-key": "catalog:",
+    "@better-auth/i18n": "catalog:",
     "@struxa/db": "workspace:*",
     "@struxa/env": "workspace:*",
     "@types/nodemailer": "^8.0.0",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,6 +3,7 @@ import { db, settings } from "@struxa/db";
 import * as schema from "@struxa/db/schema/auth";
 import { env } from "@struxa/env/server";
 import { apiKey } from "@better-auth/api-key";
+import { i18n } from "@better-auth/i18n";
 import { betterAuth } from "better-auth";
 import { APIError, createAuthMiddleware } from "better-auth/api";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -125,6 +126,68 @@ async function buildAuth(): Promise<AuthInstance> {
       admin(),
       twoFactor({ issuer: appName }),
       apiKey(),
+      i18n({
+        detection: ["cookie", "header"],
+        localeCookie: "NEXT_LOCALE",
+        translations: {
+          pl: {
+            INVALID_EMAIL_OR_PASSWORD: "Nieprawidłowy adres e-mail lub hasło.",
+            USER_NOT_FOUND: "Nie znaleziono użytkownika.",
+            USER_EMAIL_NOT_FOUND: "Nie znaleziono użytkownika z tym adresem e-mail.",
+            INVALID_PASSWORD: "Nieprawidłowe hasło.",
+            EMAIL_NOT_VERIFIED: "Adres e-mail nie został zweryfikowany.",
+            USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL: "Użytkownik z tym adresem e-mail już istnieje.",
+            PASSWORD_TOO_SHORT: "Hasło jest za krótkie.",
+            PASSWORD_TOO_LONG: "Hasło jest za długie.",
+            SESSION_EXPIRED: "Sesja wygasła. Zaloguj się ponownie.",
+            CREDENTIAL_ACCOUNT_NOT_FOUND: "Nie znaleziono konta.",
+            FAILED_TO_CREATE_USER: "Nie udało się utworzyć konta. Spróbuj ponownie.",
+            FAILED_TO_CREATE_SESSION: "Nie udało się utworzyć sesji. Spróbuj ponownie.",
+          },
+          de: {
+            INVALID_EMAIL_OR_PASSWORD: "Ungültige E-Mail-Adresse oder Passwort.",
+            USER_NOT_FOUND: "Benutzer nicht gefunden.",
+            USER_EMAIL_NOT_FOUND: "Kein Benutzer mit dieser E-Mail-Adresse gefunden.",
+            INVALID_PASSWORD: "Ungültiges Passwort.",
+            EMAIL_NOT_VERIFIED: "E-Mail-Adresse ist nicht verifiziert.",
+            USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL: "Ein Benutzer mit dieser E-Mail-Adresse existiert bereits.",
+            PASSWORD_TOO_SHORT: "Das Passwort ist zu kurz.",
+            PASSWORD_TOO_LONG: "Das Passwort ist zu lang.",
+            SESSION_EXPIRED: "Sitzung abgelaufen. Bitte erneut anmelden.",
+            CREDENTIAL_ACCOUNT_NOT_FOUND: "Konto nicht gefunden.",
+            FAILED_TO_CREATE_USER: "Konto konnte nicht erstellt werden. Bitte erneut versuchen.",
+            FAILED_TO_CREATE_SESSION: "Sitzung konnte nicht erstellt werden. Bitte erneut versuchen.",
+          },
+          es: {
+            INVALID_EMAIL_OR_PASSWORD: "Correo electrónico o contraseña incorrectos.",
+            USER_NOT_FOUND: "Usuario no encontrado.",
+            USER_EMAIL_NOT_FOUND: "No se encontró ningún usuario con ese correo electrónico.",
+            INVALID_PASSWORD: "Contraseña incorrecta.",
+            EMAIL_NOT_VERIFIED: "El correo electrónico no está verificado.",
+            USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL: "Ya existe un usuario con este correo electrónico.",
+            PASSWORD_TOO_SHORT: "La contraseña es demasiado corta.",
+            PASSWORD_TOO_LONG: "La contraseña es demasiado larga.",
+            SESSION_EXPIRED: "La sesión ha expirado. Inicia sesión de nuevo.",
+            CREDENTIAL_ACCOUNT_NOT_FOUND: "Cuenta no encontrada.",
+            FAILED_TO_CREATE_USER: "No se pudo crear la cuenta. Inténtalo de nuevo.",
+            FAILED_TO_CREATE_SESSION: "No se pudo crear la sesión. Inténtalo de nuevo.",
+          },
+          fr: {
+            INVALID_EMAIL_OR_PASSWORD: "Adresse e-mail ou mot de passe incorrect.",
+            USER_NOT_FOUND: "Utilisateur introuvable.",
+            USER_EMAIL_NOT_FOUND: "Aucun utilisateur trouvé avec cette adresse e-mail.",
+            INVALID_PASSWORD: "Mot de passe incorrect.",
+            EMAIL_NOT_VERIFIED: "L'adresse e-mail n'est pas vérifiée.",
+            USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL: "Un utilisateur avec cette adresse e-mail existe déjà.",
+            PASSWORD_TOO_SHORT: "Le mot de passe est trop court.",
+            PASSWORD_TOO_LONG: "Le mot de passe est trop long.",
+            SESSION_EXPIRED: "Session expirée. Veuillez vous reconnecter.",
+            CREDENTIAL_ACCOUNT_NOT_FOUND: "Compte introuvable.",
+            FAILED_TO_CREATE_USER: "Impossible de créer le compte. Veuillez réessayer.",
+            FAILED_TO_CREATE_SESSION: "Impossible de créer la session. Veuillez réessayer.",
+          },
+        },
+      }),
       ...(env.TURNSTILE_SECRET_KEY
         ? [
             captcha({


### PR DESCRIPTION
## Summary

- Redesigns all auth pages with a two-column split layout (brand panel left, form panel right); register page reverses the order
- Replaces Alert-based form errors with an inline \`FieldError\` component placed below the submit button
- Migrates 2FA page to \`@struxa/ui\` Label/Input/Button components
- Adds \`@better-auth/i18n\` plugin with translations for pl/de/es/fr covering all common auth error codes
- Adds SMTP-gated \`/forgot-password\` and \`/reset-password\` pages — both redirect to \`/login\` if SMTP is not configured
- "Forgot password?" link in the login form only renders when \`smtpEnabled\` is true (exposed via \`AuthSettingsProvider\`)

## Test plan

- [ ] Login and register pages show correct two-column layout on desktop (≥1024px), single column on mobile
- [ ] Register page has form on the left, brand panel on the right
- [ ] Field errors appear below the submit button, not above
- [ ] With SMTP disabled: no "Forgot password?" link in login; \`/forgot-password\` and \`/reset-password\` redirect to \`/login\`
- [ ] With SMTP enabled: full reset flow works end-to-end (request email → click link → set new password → redirected to login)
- [ ] Auth errors (wrong password, duplicate email) appear translated when browser/cookie locale is pl/de/es/fr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785088541&installation_id=134947697&pr_number=17&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F17&signature=428c0e5d1739884b08825cb51a675f990e9de0fbf24720448630da13f0166e1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->