### PR TITLE
feat: EULA and Java version alert dialogs on server console

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -252,6 +252,8 @@
       "eulaAcceptedToast": "EULA akzeptiert. Starte den Server neu, um die Änderungen anzuwenden.",
       "javaTitle": "Java-Versionskonflikt",
       "javaDescription": "Der Server erfordert eine andere Java-Version. Aktualisiere die Startvariable JAVA_VERSION in den Einstellungen entsprechend.",
+      "javaApply": "Anwenden & Neu starten",
+      "javaImageUpdatedToast": "Docker-Image aktualisiert. Starte den Server neu, um die Änderungen anzuwenden.",
       "javaGoToSettings": "Zu den Einstellungen"
     },
     "server": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -245,7 +245,14 @@
       "statsMemory": "Speicher",
       "statsDisk": "Festplatte",
       "statsInbound": "Eingehend",
-      "statsOutbound": "Ausgehend"
+      "statsOutbound": "Ausgehend",
+      "eulaTitle": "Minecraft EULA",
+      "eulaDescription": "Dieser Server erfordert deine Zustimmung zur Minecraft-Endnutzerlizenzvereinbarung, bevor er gestartet werden kann. Mit der Annahme stimmst du den Bedingungen unter aka.ms/MinecraftEULA zu.",
+      "eulaAccept": "Akzeptieren & Fortfahren",
+      "eulaAcceptedToast": "EULA akzeptiert. Starte den Server neu, um die Änderungen anzuwenden.",
+      "javaTitle": "Java-Versionskonflikt",
+      "javaDescription": "Der Server erfordert eine andere Java-Version. Aktualisiere die Startvariable JAVA_VERSION in den Einstellungen entsprechend.",
+      "javaGoToSettings": "Zu den Einstellungen"
     },
     "server": {
       "suspended": "Gesperrt",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -250,6 +250,7 @@
       "eulaDescription": "Dieser Server erfordert deine Zustimmung zur Minecraft-Endnutzerlizenzvereinbarung, bevor er gestartet werden kann. Mit der Annahme stimmst du den Bedingungen unter aka.ms/MinecraftEULA zu.",
       "eulaAccept": "Akzeptieren & Fortfahren",
       "eulaAcceptedToast": "EULA akzeptiert. Starte den Server neu, um die Änderungen anzuwenden.",
+      "eulaErrorToast": "EULA konnte nicht akzeptiert werden",
       "javaTitle": "Java-Versionskonflikt",
       "javaDescription": "Der Server erfordert eine andere Java-Version. Aktualisiere die Startvariable JAVA_VERSION in den Einstellungen entsprechend.",
       "javaApply": "Anwenden & Neu starten",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -383,6 +383,8 @@
       "eulaAcceptedToast": "EULA accepted. Restart the server to apply.",
       "javaTitle": "Java Version Mismatch",
       "javaDescription": "The server requires a different Java version. Update the JAVA_VERSION startup variable in Settings to match your server's requirements.",
+      "javaApply": "Apply & Restart",
+      "javaImageUpdatedToast": "Docker image updated. Restart the server to apply.",
       "javaGoToSettings": "Go to Settings"
     },
     "server": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -376,7 +376,14 @@
       "statsMemory": "Memory",
       "statsDisk": "Disk",
       "statsInbound": "Inbound",
-      "statsOutbound": "Outbound"
+      "statsOutbound": "Outbound",
+      "eulaTitle": "Minecraft EULA",
+      "eulaDescription": "This server requires you to agree to the Minecraft End User License Agreement before it can start. By accepting, you agree to the terms at aka.ms/MinecraftEULA.",
+      "eulaAccept": "Accept & Continue",
+      "eulaAcceptedToast": "EULA accepted. Restart the server to apply.",
+      "javaTitle": "Java Version Mismatch",
+      "javaDescription": "The server requires a different Java version. Update the JAVA_VERSION startup variable in Settings to match your server's requirements.",
+      "javaGoToSettings": "Go to Settings"
     },
     "server": {
       "suspended": "Suspended",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -381,6 +381,7 @@
       "eulaDescription": "This server requires you to agree to the Minecraft End User License Agreement before it can start. By accepting, you agree to the terms at aka.ms/MinecraftEULA.",
       "eulaAccept": "Accept & Continue",
       "eulaAcceptedToast": "EULA accepted. Restart the server to apply.",
+      "eulaErrorToast": "Failed to accept EULA",
       "javaTitle": "Java Version Mismatch",
       "javaDescription": "The server requires a different Java version. Update the JAVA_VERSION startup variable in Settings to match your server's requirements.",
       "javaApply": "Apply & Restart",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -250,6 +250,7 @@
       "eulaDescription": "Este servidor requiere que aceptes el Acuerdo de licencia de usuario final de Minecraft antes de iniciarse. Al aceptar, aceptas los términos en aka.ms/MinecraftEULA.",
       "eulaAccept": "Aceptar y continuar",
       "eulaAcceptedToast": "EULA aceptada. Reinicia el servidor para aplicar los cambios.",
+      "eulaErrorToast": "Error al aceptar la EULA",
       "javaTitle": "Incompatibilidad de versión de Java",
       "javaDescription": "El servidor requiere una versión de Java diferente. Actualiza la variable de inicio JAVA_VERSION en los ajustes.",
       "javaApply": "Aplicar y reiniciar",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -252,6 +252,8 @@
       "eulaAcceptedToast": "EULA aceptada. Reinicia el servidor para aplicar los cambios.",
       "javaTitle": "Incompatibilidad de versión de Java",
       "javaDescription": "El servidor requiere una versión de Java diferente. Actualiza la variable de inicio JAVA_VERSION en los ajustes.",
+      "javaApply": "Aplicar y reiniciar",
+      "javaImageUpdatedToast": "Imagen Docker actualizada. Reinicia el servidor para aplicar los cambios.",
       "javaGoToSettings": "Ir a ajustes"
     },
     "server": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -245,7 +245,14 @@
       "statsMemory": "Memoria",
       "statsDisk": "Disco",
       "statsInbound": "Entrante",
-      "statsOutbound": "Saliente"
+      "statsOutbound": "Saliente",
+      "eulaTitle": "EULA de Minecraft",
+      "eulaDescription": "Este servidor requiere que aceptes el Acuerdo de licencia de usuario final de Minecraft antes de iniciarse. Al aceptar, aceptas los términos en aka.ms/MinecraftEULA.",
+      "eulaAccept": "Aceptar y continuar",
+      "eulaAcceptedToast": "EULA aceptada. Reinicia el servidor para aplicar los cambios.",
+      "javaTitle": "Incompatibilidad de versión de Java",
+      "javaDescription": "El servidor requiere una versión de Java diferente. Actualiza la variable de inicio JAVA_VERSION en los ajustes.",
+      "javaGoToSettings": "Ir a ajustes"
     },
     "server": {
       "suspended": "Suspendido",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -245,7 +245,14 @@
       "statsMemory": "Mémoire",
       "statsDisk": "Disque",
       "statsInbound": "Entrant",
-      "statsOutbound": "Sortant"
+      "statsOutbound": "Sortant",
+      "eulaTitle": "CLUF Minecraft",
+      "eulaDescription": "Ce serveur nécessite que vous acceptiez le Contrat de licence utilisateur final de Minecraft avant de démarrer. En acceptant, vous acceptez les conditions disponibles sur aka.ms/MinecraftEULA.",
+      "eulaAccept": "Accepter et continuer",
+      "eulaAcceptedToast": "CLUF accepté. Redémarrez le serveur pour appliquer les modifications.",
+      "javaTitle": "Version Java incompatible",
+      "javaDescription": "Le serveur nécessite une version Java différente. Mettez à jour la variable de démarrage JAVA_VERSION dans les paramètres.",
+      "javaGoToSettings": "Aller aux paramètres"
     },
     "server": {
       "suspended": "Suspendu",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -250,6 +250,7 @@
       "eulaDescription": "Ce serveur nécessite que vous acceptiez le Contrat de licence utilisateur final de Minecraft avant de démarrer. En acceptant, vous acceptez les conditions disponibles sur aka.ms/MinecraftEULA.",
       "eulaAccept": "Accepter et continuer",
       "eulaAcceptedToast": "CLUF accepté. Redémarrez le serveur pour appliquer les modifications.",
+      "eulaErrorToast": "Impossible d'accepter le CLUF",
       "javaTitle": "Version Java incompatible",
       "javaDescription": "Le serveur nécessite une version Java différente. Mettez à jour la variable de démarrage JAVA_VERSION dans les paramètres.",
       "javaApply": "Appliquer et redémarrer",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -252,6 +252,8 @@
       "eulaAcceptedToast": "CLUF accepté. Redémarrez le serveur pour appliquer les modifications.",
       "javaTitle": "Version Java incompatible",
       "javaDescription": "Le serveur nécessite une version Java différente. Mettez à jour la variable de démarrage JAVA_VERSION dans les paramètres.",
+      "javaApply": "Appliquer et redémarrer",
+      "javaImageUpdatedToast": "Image Docker mise à jour. Redémarrez le serveur pour appliquer les modifications.",
       "javaGoToSettings": "Aller aux paramètres"
     },
     "server": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -250,6 +250,7 @@
       "eulaDescription": "Ten serwer wymaga akceptacji Umowy licencyjnej użytkownika końcowego Minecraft przed uruchomieniem. Akceptując, zgadzasz się z warunkami dostępnymi pod adresem aka.ms/MinecraftEULA.",
       "eulaAccept": "Akceptuj i kontynuuj",
       "eulaAcceptedToast": "EULA zaakceptowana. Uruchom ponownie serwer, aby zastosować zmiany.",
+      "eulaErrorToast": "Nie udało się zaakceptować EULA",
       "javaTitle": "Niezgodność wersji Java",
       "javaDescription": "Serwer wymaga innej wersji Java. Zaktualizuj zmienną startową JAVA_VERSION w ustawieniach.",
       "javaApply": "Zastosuj i uruchom ponownie",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -252,6 +252,8 @@
       "eulaAcceptedToast": "EULA zaakceptowana. Uruchom ponownie serwer, aby zastosować zmiany.",
       "javaTitle": "Niezgodność wersji Java",
       "javaDescription": "Serwer wymaga innej wersji Java. Zaktualizuj zmienną startową JAVA_VERSION w ustawieniach.",
+      "javaApply": "Zastosuj i uruchom ponownie",
+      "javaImageUpdatedToast": "Obraz Docker zaktualizowany. Uruchom ponownie serwer, aby zastosować zmiany.",
       "javaGoToSettings": "Przejdź do ustawień"
     },
     "server": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -245,7 +245,14 @@
       "statsMemory": "Pamięć",
       "statsDisk": "Dysk",
       "statsInbound": "Przychodzące",
-      "statsOutbound": "Wychodzące"
+      "statsOutbound": "Wychodzące",
+      "eulaTitle": "Minecraft EULA",
+      "eulaDescription": "Ten serwer wymaga akceptacji Umowy licencyjnej użytkownika końcowego Minecraft przed uruchomieniem. Akceptując, zgadzasz się z warunkami dostępnymi pod adresem aka.ms/MinecraftEULA.",
+      "eulaAccept": "Akceptuj i kontynuuj",
+      "eulaAcceptedToast": "EULA zaakceptowana. Uruchom ponownie serwer, aby zastosować zmiany.",
+      "javaTitle": "Niezgodność wersji Java",
+      "javaDescription": "Serwer wymaga innej wersji Java. Zaktualizuj zmienną startową JAVA_VERSION w ustawieniach.",
+      "javaGoToSettings": "Przejdź do ustawień"
     },
     "server": {
       "suspended": "Zawieszony",

--- a/apps/web/src/app/(admin)/admin/nests/[id]/eggs/[eggId]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/nests/[id]/eggs/[eggId]/page.tsx
@@ -212,7 +212,14 @@ export default function EggDetailPage({
   const nest = nests?.find((n) => n.id === nestId);
 
   const updateMutation = useMutation(
-    orpc.eggs.update.mutationOptions({ onSuccess: () => invalidateEgg(eggId) }),
+    orpc.eggs.update.mutationOptions({
+      onSuccess: (updatedEgg) => {
+        queryClient.setQueryData(
+          orpc.eggs.get.queryOptions({ input: { id: eggId } }).queryKey,
+          updatedEgg,
+        );
+      },
+    }),
   );
   const addVariableMutation = useMutation(
     orpc.eggs.addVariable.mutationOptions({ onSuccess: () => invalidateEgg(eggId) }),

--- a/apps/web/src/app/(panel)/servers/[id]/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/page.tsx
@@ -263,7 +263,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
               eulaShownRef.current = true;
               setEulaDialogOpen(true);
             }
-            if (features.includes("java_version") && !javaShownRef.current && /unsupported java|requires java/i.test(line)) {
+            if (features.includes("java_version") && !javaShownRef.current && /unrecognized option|could not create the java virtual machine|unsupported java|requires java/i.test(line)) {
               javaShownRef.current = true;
               setJavaDialogOpen(true);
             }

--- a/apps/web/src/app/(panel)/servers/[id]/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/page.tsx
@@ -21,6 +21,14 @@ import { orpc } from "@/utils/orpc";
 import { authClient } from "@/lib/auth-client";
 import { toast } from "sonner";
 import Loader from "@/components/loader";
+import {
+  Dialog,
+  DialogPopup,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@struxa/ui/components/dialog";
 
 function fmtUptime(ms: number): string {
   if (ms <= 0) return "—";
@@ -173,6 +181,7 @@ const EMPTY_HISTORY = Array(60).fill(0) as number[];
 export default function ServerPage({ params }: { params: Promise<{ id: string }> }) {
   const t = useTranslations("panel.console");
   const tStatus = useTranslations("panel.serverStatus");
+  const tc = useTranslations("common");
   const router = useRouter();
   const { data: session, isPending } = authClient.useSession();
   const { id } = use(params);
@@ -199,8 +208,21 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
   const [diskHistory, setDiskHistory] = useState<number[]>(EMPTY_HISTORY);
   const [rxHistory, setRxHistory] = useState<number[]>(EMPTY_HISTORY);
   const [txHistory, setTxHistory] = useState<number[]>(EMPTY_HISTORY);
+  const [eulaDialogOpen, setEulaDialogOpen] = useState(false);
+  const [javaDialogOpen, setJavaDialogOpen] = useState(false);
+  const eulaShownRef = useRef(false);
+  const javaShownRef = useRef(false);
 
   const { data: server } = useQuery(orpc.servers.get.queryOptions({ input: { id } }));
+  const eggFeaturesRef = useRef<string[]>([]);
+  useEffect(() => {
+    try {
+      const parsed = JSON.parse(server?.egg?.features ?? "[]") as string[];
+      eggFeaturesRef.current = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      eggFeaturesRef.current = [];
+    }
+  }, [server?.egg?.features]);
 
   const [reconnectKey, setReconnectKey] = useState(0);
 
@@ -236,6 +258,15 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
           } else if (msg.event === "console output") {
             const line = msg.args?.[0] ?? "";
             setLines((prev) => [...prev.slice(-499), line]);
+            const features = eggFeaturesRef.current;
+            if (features.includes("eula") && !eulaShownRef.current && /you need to agree to the eula/i.test(line)) {
+              eulaShownRef.current = true;
+              setEulaDialogOpen(true);
+            }
+            if (features.includes("java_version") && !javaShownRef.current && /unsupported java|requires java/i.test(line)) {
+              javaShownRef.current = true;
+              setJavaDialogOpen(true);
+            }
           } else if (msg.event === "stats") {
             try {
               const raw = JSON.parse(msg.args?.[0] ?? "{}") as {
@@ -320,6 +351,25 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
     ...orpc.servers.power.mutationOptions(),
     onError: (error) => toast.error(error.message),
   });
+
+  const [eulaAccepting, setEulaAccepting] = useState(false);
+  async function acceptEula() {
+    setEulaAccepting(true);
+    try {
+      const res = await fetch(`/api/servers/${id}/files/write?file=${encodeURIComponent("/eula.txt")}`, {
+        method: "POST",
+        headers: { "Content-Type": "text/plain" },
+        body: "#By changing the setting below to TRUE you are indicating your agreement to our EULA (https://aka.ms/MinecraftEULA).\neula=true\n",
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setEulaDialogOpen(false);
+      toast.success(t("eulaAcceptedToast"));
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to accept EULA");
+    } finally {
+      setEulaAccepting(false);
+    }
+  }
 
   function sendCommand() {
     if (!command.trim() || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
@@ -493,6 +543,50 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
           </div>
         </aside>
       </div>
+
+      <Dialog open={eulaDialogOpen} onOpenChange={setEulaDialogOpen}>
+        <DialogPopup showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>{t("eulaTitle")}</DialogTitle>
+            <DialogDescription>{t("eulaDescription")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => setEulaDialogOpen(false)}
+              className="rounded-lg px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted"
+            >
+              {tc("cancel")}
+            </button>
+            <button
+              type="button"
+              disabled={eulaAccepting}
+              onClick={() => void acceptEula()}
+              className="rounded-lg bg-green-500/20 px-3 py-1.5 text-sm font-medium text-green-400 transition-colors hover:bg-green-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {t("eulaAccept")}
+            </button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+
+      <Dialog open={javaDialogOpen} onOpenChange={setJavaDialogOpen}>
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>{t("javaTitle")}</DialogTitle>
+            <DialogDescription>{t("javaDescription")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => { setJavaDialogOpen(false); router.push(`/servers/${id}/settings`); }}
+              className="rounded-lg bg-blue-500/20 px-3 py-1.5 text-sm font-medium text-blue-400 transition-colors hover:bg-blue-500/30"
+            >
+              {t("javaGoToSettings")}
+            </button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
     </>
   );
 }

--- a/apps/web/src/app/(panel)/servers/[id]/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/page.tsx
@@ -611,7 +611,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
                   <span className="truncate">{dockerImageOptions.find((o) => o.tag === javaSelectedImage)?.label ?? javaSelectedImage}</span>
                   <ChevronDown className="ml-2 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-[var(--trigger-width)] shadow-md">
+                <DropdownMenuContent className="shadow-md">
                   {dockerImageOptions.map(({ tag, label }) => (
                     <DropdownMenuItem
                       key={tag}

--- a/apps/web/src/app/(panel)/servers/[id]/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/page.tsx
@@ -29,6 +29,13 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@struxa/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@struxa/ui/components/dropdown-menu";
+import { ChevronDown } from "lucide-react";
 
 function fmtUptime(ms: number): string {
   if (ms <= 0) return "—";
@@ -599,15 +606,24 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
           </DialogHeader>
           {dockerImageOptions.length > 0 && (
             <div className="px-5 py-3">
-              <select
-                value={javaSelectedImage}
-                onChange={(e) => setJavaSelectedImage(e.target.value)}
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring transition-colors"
-              >
-                {dockerImageOptions.map(({ tag, label }) => (
-                  <option key={tag} value={tag}>{label}</option>
-                ))}
-              </select>
+              <DropdownMenu>
+                <DropdownMenuTrigger className="flex w-full items-center justify-between rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors hover:border-border/80 hover:bg-muted data-[popup-open]:border-ring">
+                  <span className="truncate">{dockerImageOptions.find((o) => o.tag === javaSelectedImage)?.label ?? javaSelectedImage}</span>
+                  <ChevronDown className="ml-2 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-[var(--trigger-width)] shadow-md">
+                  {dockerImageOptions.map(({ tag, label }) => (
+                    <DropdownMenuItem
+                      key={tag}
+                      onClick={() => setJavaSelectedImage(tag)}
+                      className="flex cursor-pointer items-center gap-2.5 text-sm"
+                    >
+                      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${tag === javaSelectedImage ? "bg-green-500" : "bg-transparent"}`} />
+                      {label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           )}
           <DialogFooter>

--- a/apps/web/src/app/(panel)/servers/[id]/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/page.tsx
@@ -210,11 +210,13 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
   const [txHistory, setTxHistory] = useState<number[]>(EMPTY_HISTORY);
   const [eulaDialogOpen, setEulaDialogOpen] = useState(false);
   const [javaDialogOpen, setJavaDialogOpen] = useState(false);
+  const [javaSelectedImage, setJavaSelectedImage] = useState("");
   const eulaShownRef = useRef(false);
   const javaShownRef = useRef(false);
 
   const { data: server } = useQuery(orpc.servers.get.queryOptions({ input: { id } }));
   const eggFeaturesRef = useRef<string[]>([]);
+  const serverImageRef = useRef("");
   useEffect(() => {
     try {
       const parsed = JSON.parse(server?.egg?.features ?? "[]") as string[];
@@ -222,7 +224,8 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
     } catch {
       eggFeaturesRef.current = [];
     }
-  }, [server?.egg?.features]);
+    serverImageRef.current = server?.image ?? "";
+  }, [server?.egg?.features, server?.image]);
 
   const [reconnectKey, setReconnectKey] = useState(0);
 
@@ -265,6 +268,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
             }
             if (features.includes("java_version") && !javaShownRef.current && /unrecognized option|could not create the java virtual machine|unsupported java|requires java/i.test(line)) {
               javaShownRef.current = true;
+              setJavaSelectedImage(serverImageRef.current);
               setJavaDialogOpen(true);
             }
           } else if (msg.event === "stats") {
@@ -371,6 +375,16 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
     }
   }
 
+  const updateImageMutation = useMutation({
+    ...orpc.servers.updateDockerImage.mutationOptions(),
+    onSuccess: () => {
+      setJavaDialogOpen(false);
+      void queryClient.invalidateQueries(orpc.servers.get.queryOptions({ input: { id } }));
+      toast.success(t("javaImageUpdatedToast"));
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
   function sendCommand() {
     if (!command.trim() || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
     wsRef.current.send(JSON.stringify({ event: "send command", args: [command.trim()] }));
@@ -396,6 +410,13 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
       : wsStatus === "starting" || wsStatus === "stopping"
         ? "#f59e0b"
         : "#71717a";
+
+  const dockerImageOptions: { tag: string; label: string }[] = (() => {
+    try {
+      const parsed = JSON.parse(server?.egg?.dockerImages ?? "{}") as Record<string, string>;
+      return Object.entries(parsed).map(([alias, tag]) => ({ tag, label: alias || tag }));
+    } catch { return []; }
+  })();
 
   return (
     <>
@@ -571,18 +592,39 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
       </Dialog>
 
       <Dialog open={javaDialogOpen} onOpenChange={setJavaDialogOpen}>
-        <DialogPopup>
+        <DialogPopup showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>{t("javaTitle")}</DialogTitle>
             <DialogDescription>{t("javaDescription")}</DialogDescription>
           </DialogHeader>
+          {dockerImageOptions.length > 0 && (
+            <div className="px-5 py-3">
+              <select
+                value={javaSelectedImage}
+                onChange={(e) => setJavaSelectedImage(e.target.value)}
+                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring transition-colors"
+              >
+                {dockerImageOptions.map(({ tag, label }) => (
+                  <option key={tag} value={tag}>{label}</option>
+                ))}
+              </select>
+            </div>
+          )}
           <DialogFooter>
             <button
               type="button"
-              onClick={() => { setJavaDialogOpen(false); router.push(`/servers/${id}/settings`); }}
-              className="rounded-lg bg-blue-500/20 px-3 py-1.5 text-sm font-medium text-blue-400 transition-colors hover:bg-blue-500/30"
+              onClick={() => setJavaDialogOpen(false)}
+              className="rounded-lg px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted"
             >
-              {t("javaGoToSettings")}
+              {tc("cancel")}
+            </button>
+            <button
+              type="button"
+              disabled={updateImageMutation.isPending || !javaSelectedImage}
+              onClick={() => updateImageMutation.mutate({ serverId: id, image: javaSelectedImage })}
+              className="rounded-lg bg-blue-500/20 px-3 py-1.5 text-sm font-medium text-blue-400 transition-colors hover:bg-blue-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {t("javaApply")}
             </button>
           </DialogFooter>
         </DialogPopup>

--- a/apps/web/src/app/(panel)/servers/[id]/page.tsx
+++ b/apps/web/src/app/(panel)/servers/[id]/page.tsx
@@ -225,6 +225,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
   const eggFeaturesRef = useRef<string[]>([]);
   const serverImageRef = useRef("");
   useEffect(() => {
+    const prev = eggFeaturesRef.current;
     try {
       const parsed = JSON.parse(server?.egg?.features ?? "[]") as string[];
       eggFeaturesRef.current = Array.isArray(parsed) ? parsed : [];
@@ -232,7 +233,19 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
       eggFeaturesRef.current = [];
     }
     serverImageRef.current = server?.image ?? "";
-  }, [server?.egg?.features, server?.image]);
+    const features = eggFeaturesRef.current;
+    if (prev.length === 0 && features.length > 0) {
+      if (features.includes("eula") && !eulaShownRef.current && lines.some((l) => /you need to agree to the eula/i.test(l))) {
+        eulaShownRef.current = true;
+        setEulaDialogOpen(true);
+      }
+      if (features.includes("java_version") && !javaShownRef.current && lines.some((l) => /unrecognized option|could not create the java virtual machine|unsupported java|requires java/i.test(l))) {
+        javaShownRef.current = true;
+        setJavaSelectedImage(serverImageRef.current);
+        setJavaDialogOpen(true);
+      }
+    }
+  }, [server?.egg?.features, server?.image, lines]);
 
   const [reconnectKey, setReconnectKey] = useState(0);
 
@@ -376,7 +389,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
       setEulaDialogOpen(false);
       toast.success(t("eulaAcceptedToast"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to accept EULA");
+      toast.error(e instanceof Error ? e.message : t("eulaErrorToast"));
     } finally {
       setEulaAccepting(false);
     }
@@ -572,7 +585,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
         </aside>
       </div>
 
-      <Dialog open={eulaDialogOpen} onOpenChange={setEulaDialogOpen}>
+      <Dialog open={eulaDialogOpen} onOpenChange={(open) => { if (!open) eulaShownRef.current = false; setEulaDialogOpen(open); }}>
         <DialogPopup showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>{t("eulaTitle")}</DialogTitle>
@@ -598,7 +611,7 @@ export default function ServerPage({ params }: { params: Promise<{ id: string }>
         </DialogPopup>
       </Dialog>
 
-      <Dialog open={javaDialogOpen} onOpenChange={setJavaDialogOpen}>
+      <Dialog open={javaDialogOpen} onOpenChange={(open) => { if (!open) javaShownRef.current = false; setJavaDialogOpen(open); }}>
         <DialogPopup showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>{t("javaTitle")}</DialogTitle>

--- a/packages/api/src/routers/eggs.ts
+++ b/packages/api/src/routers/eggs.ts
@@ -237,6 +237,7 @@ export const eggsRouter = {
           rules?: string;
         }>;
         docker_images?: Record<string, string>;
+        features?: string[] | null;
       };
 
       const id = randomUUID();
@@ -250,6 +251,7 @@ export const eggsRouter = {
         description: raw.description ?? null,
         startup: raw.startup ?? "",
         dockerImages: JSON.stringify(raw.docker_images ?? {}),
+        features: raw.features?.length ? JSON.stringify(raw.features) : null,
         stopCommand: raw.config?.stop ?? null,
         configFiles: raw.config?.files ?? null,
         configStartup: raw.config?.startup ?? null,

--- a/packages/api/src/routers/servers.ts
+++ b/packages/api/src/routers/servers.ts
@@ -456,7 +456,7 @@ export const serversRouter = {
           allocation: { columns: { ip: true, ipAlias: true, port: true } },
           node: { columns: { name: true, fqdn: true, daemonSFTP: true } },
           egg: {
-            columns: { id: true, uuid: true, name: true, startup: true, dockerImages: true },
+            columns: { id: true, uuid: true, name: true, startup: true, dockerImages: true, features: true },
             with: {
               variables: {
                 columns: {


### PR DESCRIPTION
## Summary

- When an egg has the `eula` feature flag, the console now watches for the Minecraft EULA prompt and shows an alert dialog — accepting writes `eula=true` to `eula.txt` via the file proxy
- When an egg has the `java_version` feature flag, Java version mismatch output triggers an info dialog linking to the startup settings
- Fixed egg features disappearing after save (stale TanStack Query cache was re-triggering the init `useEffect` — now uses `setQueryData` from the mutation result)
- Fixed `importJson` silently dropping the `features` field from imported Pterodactyl egg JSON
- Exposed `egg.features` in the `servers.get` endpoint so the console page knows which features are active
- All 5 locales synced (en, de, es, fr, pl)

## Test plan

- [ ] Import a Pterodactyl Minecraft egg JSON with `"features": ["eula"]` → features field populated after import
- [ ] Add `eula` feature to an egg, save → feature persists without disappearing
- [ ] Start a Minecraft server without EULA accepted → EULA dialog appears on console output match
- [ ] Click Accept → `eula.txt` written, success toast shown, dialog closes
- [ ] Java mismatch console output on a server with `java_version` feature → Java dialog appears, "Go to Settings" navigates correctly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785185905&installation_id=134947697&pr_number=20&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F20&signature=40491627aa0b9a524a978daf81706d7f9a1fd0c143f8dfe63adc94087df2c0d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-screen EULA acceptance guidance for Minecraft when required, including an accept action and confirmation toast.
  * Added Java version mismatch notices that guide users to the server settings page.
  * These console prompts were expanded across supported languages.
* **Bug Fixes**
  * Improved egg/server update behavior so changes show immediately without unnecessary refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->