### PR TITLE
feat(auth): add email change flow with dedicated change-email template

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -826,6 +826,21 @@
       "saved": "Gespeichert",
       "updateFailed": "Das Passwort konnte nicht aktualisiert werden"
     },
+    "email": {
+      "dialogTitle": "E-Mail-Adresse ändern",
+      "dialogDesc": "Wir senden einen Bestätigungslink an Ihre neue Adresse. Ihre E-Mail-Adresse wird erst nach der Bestätigung geändert.",
+      "newEmailLabel": "Neue E-Mail-Adresse",
+      "newEmailPlaceholder": "neu@beispiel.de",
+      "confirmEmailLabel": "Neue E-Mail-Adresse bestätigen",
+      "confirmEmailPlaceholder": "neu@beispiel.de",
+      "emailInvalid": "Geben Sie eine gültige E-Mail-Adresse ein.",
+      "emailsDoNotMatch": "Die E-Mail-Adressen stimmen nicht überein.",
+      "sameEmail": "Die neue Adresse muss sich von der aktuellen unterscheiden.",
+      "sending": "Senden…",
+      "sent": "Bestätigungs-E-Mail gesendet",
+      "updated": "E-Mail-Adresse aktualisiert",
+      "sendFailed": "Die E-Mail-Adresse konnte nicht geändert werden"
+    },
     "apiKeys": {
       "title": "API-Schlüssel",
       "description": "Verwenden Sie API-Schlüssel, um den programmgesteuerten Zugriff auf die API zu authentifizieren.",
@@ -1572,6 +1587,7 @@
       "templatePasswordReset": "Passwort zurücksetzen",
       "templateWelcome": "Willkommen",
       "templateServerInstall": "Server-Installation",
+      "templateChangeEmail": "E-Mail-Änderung",
       "save": "Speichern",
       "saving": "Speichern…",
       "saved": "Gespeichert",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -846,6 +846,21 @@
       "saved": "Saved",
       "updateFailed": "Failed to update password"
     },
+    "email": {
+      "dialogTitle": "Change Email",
+      "dialogDesc": "We'll send a verification link to your new address. Your email is only changed once you confirm it.",
+      "newEmailLabel": "New Email",
+      "newEmailPlaceholder": "new@example.com",
+      "confirmEmailLabel": "Confirm New Email",
+      "confirmEmailPlaceholder": "new@example.com",
+      "emailInvalid": "Enter a valid email address.",
+      "emailsDoNotMatch": "Email addresses do not match.",
+      "sameEmail": "The new email must be different from your current email.",
+      "sending": "Sending…",
+      "sent": "Verification email sent",
+      "updated": "Email updated",
+      "sendFailed": "Failed to request email change"
+    },
     "apiKeys": {
       "title": "API Keys",
       "description": "Use API keys to authenticate programmatic access to the API.",
@@ -1616,6 +1631,7 @@
       "templatePasswordReset": "Password Reset",
       "templateWelcome": "Welcome",
       "templateServerInstall": "Server Install",
+      "templateChangeEmail": "Email Change",
       "save": "Save",
       "saving": "Saving…",
       "saved": "Saved",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -826,6 +826,21 @@
       "saved": "Guardado",
       "updateFailed": "No se pudo actualizar la contraseña"
     },
+    "email": {
+      "dialogTitle": "Cambiar correo electrónico",
+      "dialogDesc": "Enviaremos un enlace de verificación a su nueva dirección. Su correo solo se cambiará una vez que lo confirme.",
+      "newEmailLabel": "Nuevo correo electrónico",
+      "newEmailPlaceholder": "nuevo@ejemplo.com",
+      "confirmEmailLabel": "Confirmar nuevo correo electrónico",
+      "confirmEmailPlaceholder": "nuevo@ejemplo.com",
+      "emailInvalid": "Introduzca un correo electrónico válido.",
+      "emailsDoNotMatch": "Los correos electrónicos no coinciden.",
+      "sameEmail": "El nuevo correo debe ser diferente del actual.",
+      "sending": "Enviando…",
+      "sent": "Correo de verificación enviado",
+      "updated": "Correo electrónico actualizado",
+      "sendFailed": "No se pudo solicitar el cambio de correo"
+    },
     "apiKeys": {
       "title": "Claves API",
       "description": "Utilice claves API para autenticar el acceso programático a la API.",
@@ -1572,6 +1587,7 @@
       "templatePasswordReset": "Restablecimiento de contraseña",
       "templateWelcome": "Bienvenida",
       "templateServerInstall": "Instalación del servidor",
+      "templateChangeEmail": "Cambio de correo electrónico",
       "save": "Guardar",
       "saving": "Guardando…",
       "saved": "Guardado",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -826,6 +826,21 @@
       "saved": "Enregistr?",
       "updateFailed": "Échec de la mise à jour du mot de passe"
     },
+    "email": {
+      "dialogTitle": "Changer d'adresse e-mail",
+      "dialogDesc": "Nous enverrons un lien de vérification à votre nouvelle adresse. Votre e-mail ne sera changé qu'après confirmation.",
+      "newEmailLabel": "Nouvelle adresse e-mail",
+      "newEmailPlaceholder": "nouveau@exemple.fr",
+      "confirmEmailLabel": "Confirmer la nouvelle adresse e-mail",
+      "confirmEmailPlaceholder": "nouveau@exemple.fr",
+      "emailInvalid": "Saisissez une adresse e-mail valide.",
+      "emailsDoNotMatch": "Les adresses e-mail ne correspondent pas.",
+      "sameEmail": "La nouvelle adresse doit être différente de l'adresse actuelle.",
+      "sending": "Envoi…",
+      "sent": "E-mail de vérification envoyé",
+      "updated": "Adresse e-mail mise à jour",
+      "sendFailed": "Impossible de demander le changement d'adresse e-mail"
+    },
     "apiKeys": {
       "title": "Clés API",
       "description": "Utilisez des clés API pour authentifier l'accès programmatique à l'API.",
@@ -1572,6 +1587,7 @@
       "templatePasswordReset": "Réinitialisation du mot de passe",
       "templateWelcome": "Bienvenue",
       "templateServerInstall": "Installation du serveur",
+      "templateChangeEmail": "Changement d'adresse e-mail",
       "save": "Enregistrer",
       "saving": "Enregistrement…",
       "saved": "Enregistré",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -826,6 +826,21 @@
       "saved": "Zapisano",
       "updateFailed": "Nie udało się zaktualizować hasła"
     },
+    "email": {
+      "dialogTitle": "Zmiana adresu e-mail",
+      "dialogDesc": "Wyślemy link weryfikacyjny na nowy adres. Adres e-mail zostanie zmieniony dopiero po jego potwierdzeniu.",
+      "newEmailLabel": "Nowy adres e-mail",
+      "newEmailPlaceholder": "nowy@przyklad.pl",
+      "confirmEmailLabel": "Potwierdź nowy adres e-mail",
+      "confirmEmailPlaceholder": "nowy@przyklad.pl",
+      "emailInvalid": "Podaj prawidłowy adres e-mail.",
+      "emailsDoNotMatch": "Adresy e-mail nie pasują.",
+      "sameEmail": "Nowy adres musi różnić się od obecnego.",
+      "sending": "Wysyłanie…",
+      "sent": "Wysłano e-mail weryfikacyjny",
+      "updated": "Adres e-mail został zmieniony",
+      "sendFailed": "Nie udało się zmienić adresu e-mail"
+    },
     "apiKeys": {
       "title": "Klucze API",
       "description": "Użyj kluczy API, aby uwierzytelnić programowy dostęp do interfejsu API.",
@@ -1572,6 +1587,7 @@
       "templatePasswordReset": "Reset hasła",
       "templateWelcome": "Powitanie",
       "templateServerInstall": "Instalacja serwera",
+      "templateChangeEmail": "Zmiana adresu e-mail",
       "save": "Zapisz",
       "saving": "Zapisywanie…",
       "saved": "Zapisano",

--- a/apps/web/src/app/(admin-fullscreen)/admin/settings/email/page.tsx
+++ b/apps/web/src/app/(admin-fullscreen)/admin/settings/email/page.tsx
@@ -10,6 +10,7 @@ import type { Monaco } from "@monaco-editor/react";
 import {
   ChevronLeft,
   Mail,
+  MailPlus,
   KeyRound,
   PartyPopper,
   Server,
@@ -22,13 +23,14 @@ import { toast } from "sonner";
 import { orpc } from "@/utils/orpc";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@struxa/ui/components/select";
 
-type TemplateName = "verification" | "password-reset" | "welcome" | "server-install";
+type TemplateName = "verification" | "password-reset" | "welcome" | "server-install" | "change-email";
 
 const TEMPLATES: { name: TemplateName; icon: React.ElementType }[] = [
   { name: "verification",   icon: Mail },
   { name: "password-reset", icon: KeyRound },
   { name: "welcome",        icon: PartyPopper },
   { name: "server-install", icon: Server },
+  { name: "change-email",   icon: MailPlus },
 ];
 
 const SAMPLE_VARS: Record<string, string> = {
@@ -244,6 +246,7 @@ export default function EmailEditorPage() {
     "password-reset": t("templatePasswordReset"),
     welcome:        t("templateWelcome"),
     "server-install": t("templateServerInstall"),
+    "change-email": t("templateChangeEmail"),
   };
 
   const activeTemplate = TEMPLATES.find((t) => t.name === active)!;

--- a/apps/web/src/app/(panel)/account/page.tsx
+++ b/apps/web/src/app/(panel)/account/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { Copy, Check, Key, Plus, Trash2, Monitor, LogOut, Camera, Link2, Unlink, Download } from "lucide-react";
+import { Copy, Check, Key, Plus, Trash2, Monitor, LogOut, Camera, Link2, Unlink, Download, Pencil } from "lucide-react";
 import { motion } from "motion/react";
 import QRCode from "qrcode";
 import {
@@ -348,6 +348,115 @@ function PasswordSection({ hasPassword }: { hasPassword: boolean }) {
 }
 
 // ─────────────────────────────────────────────
+// Change Email Dialog
+// ─────────────────────────────────────────────
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function EmailChangeDialog() {
+  const t = useTranslations("account.email");
+  const tc = useTranslations("common");
+  const { data: session } = authClient.useSession();
+  const [open, setOpen] = useState(false);
+  const [newEmail, setNewEmail] = useState("");
+  const [confirmEmail, setConfirmEmail] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+
+  function reset() {
+    setOpen(false);
+    setNewEmail("");
+    setConfirmEmail("");
+    setError("");
+  }
+
+  async function handleSubmit() {
+    const next = newEmail.trim().toLowerCase();
+    if (!EMAIL_RE.test(next)) { setError(t("emailInvalid")); return; }
+    if (next === (session?.user.email ?? "").toLowerCase()) { setError(t("sameEmail")); return; }
+    if (next !== confirmEmail.trim().toLowerCase()) { setError(t("emailsDoNotMatch")); return; }
+    setError("");
+    setPending(true);
+    try {
+      const prevEmail = session?.user.email;
+      const res = await authClient.changeEmail({ newEmail: next, callbackURL: "/account" });
+      if (res.error) throw new Error(res.error.message);
+      setOpen(false);
+      const fresh = (await authClient.$fetch("/api/auth/get-session")) as { user?: { email?: string } } | null;
+      toast.success(fresh?.user?.email !== prevEmail ? t("updated") : t("sent"));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("sendFailed"));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={t("dialogTitle")}
+        title={t("dialogTitle")}
+        onClick={() => setOpen(true)}
+        className="absolute right-1.5 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      >
+        <Pencil className="h-3.5 w-3.5" />
+      </button>
+
+      <Dialog open={open} onOpenChange={(o) => { if (!o) reset(); }}>
+        <DialogPopup showCloseButton={false} className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("dialogTitle")}</DialogTitle>
+            <DialogDescription>{t("dialogDesc")}</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3 px-5 py-4">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-foreground">{t("newEmailLabel")}</label>
+              <input
+                autoFocus
+                type="email"
+                className={inputClass(true)}
+                placeholder={t("newEmailPlaceholder")}
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-foreground">{t("confirmEmailLabel")}</label>
+              <input
+                type="email"
+                className={inputClass(true)}
+                placeholder={t("confirmEmailPlaceholder")}
+                value={confirmEmail}
+                onChange={(e) => setConfirmEmail(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") void handleSubmit(); }}
+              />
+            </div>
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <DialogClose
+              className="rounded-lg px-4 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              disabled={pending}
+              onClick={reset}
+            >
+              {tc("cancel")}
+            </DialogClose>
+            <button
+              type="button"
+              disabled={pending || !newEmail || !confirmEmail}
+              onClick={() => void handleSubmit()}
+              className="rounded-lg bg-foreground px-4 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-80 disabled:opacity-40"
+            >
+              {pending ? t("sending") : tc("continue")}
+            </button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────
 // Locale Section
 // ─────────────────────────────────────────────
 const LOCALES = [
@@ -487,11 +596,14 @@ function ProfileTab() {
               </div>
               <div className="flex flex-col gap-1.5">
                 <label className="text-xs font-medium text-foreground">{t("emailLabel")}</label>
-                <input
-                  className={`${inputClass()} cursor-not-allowed opacity-60`}
-                  value={session?.user.email ?? ""}
-                  readOnly
-                />
+                <div className="relative">
+                  <input
+                    className={`${inputClass()} cursor-not-allowed opacity-60 pr-9`}
+                    value={session?.user.email ?? ""}
+                    readOnly
+                  />
+                  <EmailChangeDialog />
+                </div>
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">

--- a/apps/web/src/app/(panel)/account/page.tsx
+++ b/apps/web/src/app/(panel)/account/page.tsx
@@ -410,8 +410,9 @@ function EmailChangeDialog() {
           </DialogHeader>
           <div className="flex flex-col gap-3 px-5 py-4">
             <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-foreground">{t("newEmailLabel")}</label>
+              <label htmlFor="change-email-new" className="text-xs font-medium text-foreground">{t("newEmailLabel")}</label>
               <input
+                id="change-email-new"
                 autoFocus
                 type="email"
                 className={inputClass(true)}
@@ -421,8 +422,9 @@ function EmailChangeDialog() {
               />
             </div>
             <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-foreground">{t("confirmEmailLabel")}</label>
+              <label htmlFor="change-email-confirm" className="text-xs font-medium text-foreground">{t("confirmEmailLabel")}</label>
               <input
+                id="change-email-confirm"
                 type="email"
                 className={inputClass(true)}
                 placeholder={t("confirmEmailPlaceholder")}

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -118,7 +118,7 @@ function baseTemplate(appName: string, header: string, body: string): string {
 </html>`;
 }
 
-export const TEMPLATE_NAMES = ["verification", "password-reset", "welcome", "server-install"] as const;
+export const TEMPLATE_NAMES = ["verification", "password-reset", "welcome", "server-install", "change-email"] as const;
 export type TemplateName = (typeof TEMPLATE_NAMES)[number];
 
 export const DEFAULT_TEMPLATES: Record<TemplateName, (vars: Record<string, string>) => string> = {
@@ -163,6 +163,17 @@ export const DEFAULT_TEMPLATES: Record<TemplateName, (vars: Record<string, strin
 <p>Your server <strong>${vars.serverName ?? "your server"}</strong> has finished installing and is ready to start.</p>
 <p>Log in to your panel to start and manage your server.</p>`,
     ),
+
+  "change-email": (vars) =>
+    baseTemplate(
+      vars.appName ?? "Struxa",
+      "Confirm your new email",
+      `<h2>Confirm your new email address</h2>
+<p>Hi ${vars.userName ?? "there"},</p>
+<p>We received a request to change the email address on your account. Click the button below to confirm your new address. Your email will only be changed once you confirm it.</p>
+<p><a class="btn" href="${vars.verificationUrl ?? "#"}">Confirm Email Change</a></p>
+<p style="font-size:12px;color:#a1a1aa;">If you didn't request this change, you can safely ignore this email.<br><br>Button not working? Copy and paste this link into your browser:<br><a href="${vars.verificationUrl ?? "#"}" style="color:#52525b;word-break:break-all;">${vars.verificationUrl ?? ""}</a></p>`,
+    ),
 };
 
 export const TEMPLATE_VARIABLES: Record<TemplateName, string[]> = {
@@ -170,4 +181,5 @@ export const TEMPLATE_VARIABLES: Record<TemplateName, string[]> = {
   "password-reset": ["appName", "userName", "resetUrl", "resetToken"],
   welcome: ["appName", "userName"],
   "server-install": ["appName", "userName", "serverName"],
+  "change-email": ["appName", "userName", "verificationUrl", "verificationToken"],
 };

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -65,8 +65,19 @@ export async function getEmailTemplate(name: string): Promise<string | null> {
   return row?.value ?? null;
 }
 
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export function substituteVars(html: string, vars: Record<string, string>): string {
-  return html.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? `{{${key}}}`);
+  return html.replace(/\{\{(\w+)\}\}/g, (_, key) =>
+    vars[key] === undefined ? `{{${key}}}` : escapeHtml(vars[key]),
+  );
 }
 
 export async function sendEmail(
@@ -108,10 +119,10 @@ function baseTemplate(appName: string, header: string, body: string): string {
 <body>
 <div class="wrapper">
   <div class="card">
-    <div class="header"><h1>${appName}</h1></div>
+    <div class="header"><h1>${escapeHtml(appName)}</h1></div>
     <div class="body">${body}</div>
     <hr class="divider" />
-    <div class="footer"><p>This email was sent by ${appName}. If you didn't expect this, you can safely ignore it.</p></div>
+    <div class="footer"><p>This email was sent by ${escapeHtml(appName)}. If you didn't expect this, you can safely ignore it.</p></div>
   </div>
 </div>
 </body>
@@ -127,10 +138,10 @@ export const DEFAULT_TEMPLATES: Record<TemplateName, (vars: Record<string, strin
       vars.appName ?? "Struxa",
       "Verify your email",
       `<h2>Verify your email address</h2>
-<p>Hi ${vars.userName ?? "there"},</p>
+<p>Hi ${escapeHtml(vars.userName ?? "there")},</p>
 <p>Thanks for signing up. Click the button below to verify your email address and activate your account.</p>
-<p><a class="btn" href="${vars.verificationUrl ?? "#"}">Verify Email</a></p>
-<p style="font-size:12px;color:#a1a1aa;">Button not working? Copy and paste this link into your browser:<br><a href="${vars.verificationUrl ?? "#"}" style="color:#52525b;word-break:break-all;">${vars.verificationUrl ?? ""}</a></p>`,
+<p><a class="btn" href="${escapeHtml(vars.verificationUrl ?? "#")}">Verify Email</a></p>
+<p style="font-size:12px;color:#a1a1aa;">Button not working? Copy and paste this link into your browser:<br><a href="${escapeHtml(vars.verificationUrl ?? "#")}" style="color:#52525b;word-break:break-all;">${escapeHtml(vars.verificationUrl ?? "")}</a></p>`,
     ),
 
   "password-reset": (vars) =>
@@ -138,18 +149,18 @@ export const DEFAULT_TEMPLATES: Record<TemplateName, (vars: Record<string, strin
       vars.appName ?? "Struxa",
       "Reset your password",
       `<h2>Reset your password</h2>
-<p>Hi ${vars.userName ?? "there"},</p>
+<p>Hi ${escapeHtml(vars.userName ?? "there")},</p>
 <p>We received a request to reset the password for your account. Click the button below to choose a new password. This link expires in 1 hour.</p>
-<p><a class="btn" href="${vars.resetUrl ?? "#"}">Reset Password</a></p>
-<p style="font-size:12px;color:#a1a1aa;">If you didn't request a password reset, you can safely ignore this email. Your password won't change.<br><br>Button not working? Copy and paste this link:<br><a href="${vars.resetUrl ?? "#"}" style="color:#52525b;word-break:break-all;">${vars.resetUrl ?? ""}</a></p>`,
+<p><a class="btn" href="${escapeHtml(vars.resetUrl ?? "#")}">Reset Password</a></p>
+<p style="font-size:12px;color:#a1a1aa;">If you didn't request a password reset, you can safely ignore this email. Your password won't change.<br><br>Button not working? Copy and paste this link:<br><a href="${escapeHtml(vars.resetUrl ?? "#")}" style="color:#52525b;word-break:break-all;">${escapeHtml(vars.resetUrl ?? "")}</a></p>`,
     ),
 
   welcome: (vars) =>
     baseTemplate(
       vars.appName ?? "Struxa",
-      `Welcome to ${vars.appName ?? "Struxa"}`,
-      `<h2>Welcome to ${vars.appName ?? "Struxa"}!</h2>
-<p>Hi ${vars.userName ?? "there"},</p>
+      `Welcome to ${escapeHtml(vars.appName ?? "Struxa")}`,
+      `<h2>Welcome to ${escapeHtml(vars.appName ?? "Struxa")}!</h2>
+<p>Hi ${escapeHtml(vars.userName ?? "there")},</p>
 <p>Your account has been created and is ready to use. You can now log in and start managing your servers.</p>
 <p>If you have any questions, reach out to your panel administrator.</p>`,
     ),
@@ -159,8 +170,8 @@ export const DEFAULT_TEMPLATES: Record<TemplateName, (vars: Record<string, strin
       vars.appName ?? "Struxa",
       "Server installation complete",
       `<h2>Your server is ready</h2>
-<p>Hi ${vars.userName ?? "there"},</p>
-<p>Your server <strong>${vars.serverName ?? "your server"}</strong> has finished installing and is ready to start.</p>
+<p>Hi ${escapeHtml(vars.userName ?? "there")},</p>
+<p>Your server <strong>${escapeHtml(vars.serverName ?? "your server")}</strong> has finished installing and is ready to start.</p>
 <p>Log in to your panel to start and manage your server.</p>`,
     ),
 
@@ -169,10 +180,10 @@ export const DEFAULT_TEMPLATES: Record<TemplateName, (vars: Record<string, strin
       vars.appName ?? "Struxa",
       "Confirm your new email",
       `<h2>Confirm your new email address</h2>
-<p>Hi ${vars.userName ?? "there"},</p>
+<p>Hi ${escapeHtml(vars.userName ?? "there")},</p>
 <p>We received a request to change the email address on your account. Click the button below to confirm your new address. Your email will only be changed once you confirm it.</p>
-<p><a class="btn" href="${vars.verificationUrl ?? "#"}">Confirm Email Change</a></p>
-<p style="font-size:12px;color:#a1a1aa;">If you didn't request this change, you can safely ignore this email.<br><br>Button not working? Copy and paste this link into your browser:<br><a href="${vars.verificationUrl ?? "#"}" style="color:#52525b;word-break:break-all;">${vars.verificationUrl ?? ""}</a></p>`,
+<p><a class="btn" href="${escapeHtml(vars.verificationUrl ?? "#")}">Confirm Email Change</a></p>
+<p style="font-size:12px;color:#a1a1aa;">If you didn't request this change, you can safely ignore this email.<br><br>Button not working? Copy and paste this link into your browser:<br><a href="${escapeHtml(vars.verificationUrl ?? "#")}" style="color:#52525b;word-break:break-all;">${escapeHtml(vars.verificationUrl ?? "")}</a></p>`,
     ),
 };
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -67,22 +67,38 @@ async function buildAuth(): Promise<AuthInstance> {
         await sendEmail(svc, user.email, `Reset your ${appName} password`, html);
       },
     },
+    user: {
+      changeEmail: {
+        enabled: true,
+      },
+    },
     emailVerification: {
-      sendVerificationEmail: async ({ user, url }) => {
+      sendVerificationEmail: async ({ user, url }, request) => {
+        const isChangeEmail =
+          typeof request?.url === "string" &&
+          new URL(request.url).pathname.endsWith("/change-email");
         const svc = await buildEmailServiceFromSettings();
         if (!svc) {
-          // Email disabled — auto-verify so email/password signups aren't permanently locked out.
-          // Social logins auto-verify; this keeps consistent behaviour when no email service is set.
+          if (isChangeEmail) {
+            await db.update(schema.user)
+              .set({ email: user.email, emailVerified: true })
+              .where(eq(schema.user.id, user.id));
+            return;
+          }
           await db.update(schema.user).set({ emailVerified: true }).where(eq(schema.user.id, user.id));
           return;
         }
         const verificationToken = (() => { try { return new URL(url).searchParams.get("token") ?? ""; } catch { return ""; } })();
-        const custom = await getEmailTemplate("verification");
+        const templateName = isChangeEmail ? "change-email" : "verification";
+        const custom = await getEmailTemplate(templateName);
         const vars = { appName, userName: user.name ?? user.email, verificationUrl: url, verificationToken };
         const html = custom
           ? substituteVars(custom, vars)
-          : DEFAULT_TEMPLATES.verification(vars);
-        await sendEmail(svc, user.email, `Verify your ${appName} email`, html);
+          : DEFAULT_TEMPLATES[templateName](vars);
+        const subject = isChangeEmail
+          ? `Confirm your new ${appName} email`
+          : `Verify your ${appName} email`;
+        await sendEmail(svc, user.email, subject, html);
       },
     },
     socialProviders,


### PR DESCRIPTION
## Summary
Users can now change their account email from Account settings. A pencil icon on the existing read-only email field opens a dialog; after submitting, a verification link is sent to the new address using a new admin-editable `change-email` email template. Clicking the link completes the change via better-auth's built-in flow.

When no SMTP service is configured, the email is updated directly (mirroring the existing signup auto-verify behavior) and the toast reflects that instead of claiming an email was sent.

## Changes
- Enable `user.changeEmail` in better-auth config; branch `sendVerificationEmail` on the request path to use the new template and handle the no-SMTP case.
- Add `change-email` default email template and variables.
- Add template to the admin email editor.
- Add `account.email` strings in all 5 locales.
- UI: pencil icon in the existing email input opens the change dialog; toast distinguishes sent-vs-updated.

## Notes
- If the new email belongs to another account, better-auth returns success without sending (anti-enumeration) — the UI intentionally cannot distinguish this.
- Tested: `tsc --noEmit` for web and auth, JSON validity of all locale files, manual flow with and without SMTP.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790501941&installation_model_id=22253&pr_number=28&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F28&signature=416f1b4c70fff9cc0f81e6833b4107a9b6143a96f3d17df868a703a752583e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can change their account email from profile settings.
  - Email changes include validation, confirmation, status updates, and error feedback.
  - Administrators can edit a dedicated change-email notification template.
  - Change-email notifications use tailored confirmation content.

- **Security**
  - Email notifications now safely handle user-provided information.

- **Localization**
  - Added change-email translations in English, German, Spanish, French, and Polish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->