### PR TITLE
feat(notifications): outbound Discord & Telegram notifications

### DIFF
--- a/apps/watchkeeper/internal/workers/notifications.go
+++ b/apps/watchkeeper/internal/workers/notifications.go
@@ -266,7 +266,7 @@ func postDiscord(rawURL string, v notifMessage) error {
 		},
 	}
 	data, _ := json.Marshal(payload)
-	return httpPostJSON(withComponentsParam(rawURL), data)
+	return httpPostJSON(withComponentsParam(rawURL), data) // codeql[go/request-forgery]: safeDiscordURL enforces an HTTPS discord.com/discordapp.com allowlist before posting
 }
 
 func withComponentsParam(rawURL string) string {
@@ -281,12 +281,12 @@ func postTelegram(token, chatID, text string) error {
 		return errors.New("invalid telegram bot token")
 	}
 	body, _ := json.Marshal(map[string]string{"chat_id": chatID, "text": text})
-	return httpPostJSON(fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", token), body)
+	return httpPostJSON(fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", token), body) // codeql[go/request-forgery]: token is format-validated and the host is fixed to api.telegram.org
 }
 
 func httpPostJSON(target string, body []byte) error {
 	client := &http.Client{Timeout: notifyHTTPTimeout}
-	resp, err := client.Post(target, "application/json", bytes.NewReader(body))
+	resp, err := client.Post(target, "application/json", bytes.NewReader(body)) // codeql[go/request-forgery]: callers validate webhook URLs and bot tokens before posting
 	if err != nil {
 		var urlErr *url.Error
 		if errors.As(err, &urlErr) {

--- a/apps/watchkeeper/internal/workers/notifications.go
+++ b/apps/watchkeeper/internal/workers/notifications.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -220,7 +221,23 @@ type notifMessage struct {
 	buttonURL   string
 }
 
-func postDiscord(url string, v notifMessage) error {
+var telegramTokenPattern = regexp.MustCompile(`^[0-9]{6,}:[A-Za-z0-9_-]{30,}$`)
+
+func safeDiscordURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "https" || (u.Host != "discord.com" && u.Host != "discordapp.com") {
+		return false
+	}
+	return strings.HasPrefix(u.Path, "/api/webhooks/")
+}
+
+func postDiscord(rawURL string, v notifMessage) error {
+	if !safeDiscordURL(rawURL) {
+		return errors.New("invalid discord webhook url")
+	}
 	header := fmt.Sprintf("### ✦ %s\n%s", v.title, v.subtitle)
 	inner := []any{}
 	if v.buttonURL != "" {
@@ -249,17 +266,20 @@ func postDiscord(url string, v notifMessage) error {
 		},
 	}
 	data, _ := json.Marshal(payload)
-	return httpPostJSON(withComponentsParam(url), data)
+	return httpPostJSON(withComponentsParam(rawURL), data)
 }
 
-func withComponentsParam(url string) string {
-	if strings.Contains(url, "?") {
-		return url + "&with_components=true"
+func withComponentsParam(rawURL string) string {
+	if strings.Contains(rawURL, "?") {
+		return rawURL + "&with_components=true"
 	}
-	return url + "?with_components=true"
+	return rawURL + "?with_components=true"
 }
 
 func postTelegram(token, chatID, text string) error {
+	if !telegramTokenPattern.MatchString(token) {
+		return errors.New("invalid telegram bot token")
+	}
 	body, _ := json.Marshal(map[string]string{"chat_id": chatID, "text": text})
 	return httpPostJSON(fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", token), body)
 }

--- a/apps/watchkeeper/internal/workers/notifications.go
+++ b/apps/watchkeeper/internal/workers/notifications.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stripsior/struxa/watchkeeper/internal/crypto"
@@ -103,6 +106,51 @@ func loadOwnerConfig(db *sql.DB, userID string) (ownerNotifConfig, error) {
 	return c, nil
 }
 
+type statusNotifyJob struct {
+	serverID   string
+	serverName string
+	uuid       string
+	ownerID    string
+	state      string
+}
+
+var (
+	statusNotifyMu   sync.Mutex
+	statusNotifyJobs = map[string]statusNotifyJob{}
+	statusNotifyWake = make(chan struct{}, 1)
+)
+
+func enqueueStatusNotify(job statusNotifyJob) {
+	statusNotifyMu.Lock()
+	statusNotifyJobs[job.serverID] = job
+	statusNotifyMu.Unlock()
+	select {
+	case statusNotifyWake <- struct{}{}:
+	default:
+	}
+}
+
+func runStatusNotifyDispatcher(db *sql.DB) {
+	for range statusNotifyWake {
+		for {
+			statusNotifyMu.Lock()
+			var job statusNotifyJob
+			ok := false
+			for k, v := range statusNotifyJobs {
+				job = v
+				delete(statusNotifyJobs, k)
+				ok = true
+				break
+			}
+			statusNotifyMu.Unlock()
+			if !ok {
+				break
+			}
+			notifyServerStatus(db, job.serverID, job.serverName, job.uuid, job.ownerID, job.state)
+		}
+	}
+}
+
 func notifyServerStatus(db *sql.DB, serverID, serverName, uuid, ownerID, state string) {
 	if state != "running" && state != "offline" {
 		return
@@ -194,7 +242,8 @@ func postDiscord(url string, v notifMessage) error {
 		map[string]any{"type": 10, "content": fmt.Sprintf("-# <t:%d:R>", time.Now().Unix())},
 	)
 	payload := map[string]any{
-		"flags": 32768,
+		"flags":            32768,
+		"allowed_mentions": map[string]any{"parse": []any{}},
 		"components": []any{
 			map[string]any{"type": 17, "accent_color": nil, "components": inner},
 		},
@@ -215,10 +264,14 @@ func postTelegram(token, chatID, text string) error {
 	return httpPostJSON(fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", token), body)
 }
 
-func httpPostJSON(url string, body []byte) error {
+func httpPostJSON(target string, body []byte) error {
 	client := &http.Client{Timeout: notifyHTTPTimeout}
-	resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+	resp, err := client.Post(target, "application/json", bytes.NewReader(body))
 	if err != nil {
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			return fmt.Errorf("post request failed: %w", urlErr.Err)
+		}
 		return err
 	}
 	defer resp.Body.Close()

--- a/apps/watchkeeper/internal/workers/notifications.go
+++ b/apps/watchkeeper/internal/workers/notifications.go
@@ -1,0 +1,229 @@
+package workers
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/stripsior/struxa/watchkeeper/internal/crypto"
+)
+
+const notifyHTTPTimeout = 8 * time.Second
+
+type notifConfig struct {
+	appName           string
+	appURL            string
+	discordEnabled    bool
+	discordURL        string
+	telegramEnabled   bool
+	telegramToken     string
+	telegramChatID    string
+	userConfigEnabled bool
+}
+
+func loadNotifConfig(db *sql.DB) (notifConfig, error) {
+	rows, err := db.Query("SELECT `key`, `value` FROM settings")
+	if err != nil {
+		return notifConfig{}, err
+	}
+	defer rows.Close()
+	s := map[string]string{}
+	for rows.Next() {
+		var k, v sql.NullString
+		if err := rows.Scan(&k, &v); err != nil {
+			return notifConfig{}, err
+		}
+		s[k.String] = v.String
+	}
+	if err := rows.Err(); err != nil {
+		return notifConfig{}, err
+	}
+	cfg := notifConfig{
+		appName:           s["app_name"],
+		appURL:            os.Getenv("APP_URL"),
+		discordEnabled:    s["notifications_discord_enabled"] == "true",
+		telegramEnabled:   s["notifications_telegram_enabled"] == "true",
+		userConfigEnabled: s["notifications_user_config_enabled"] == "true",
+	}
+	if cfg.appName == "" {
+		cfg.appName = "Struxa"
+	}
+	if cfg.appURL == "" {
+		cfg.appURL = s["app_url"]
+	}
+	if v := s["notifications_discord_webhook_url"]; v != "" {
+		if plain, err := crypto.DecryptToken(v); err == nil {
+			cfg.discordURL = plain
+		}
+	}
+	if v := s["notifications_telegram_bot_token"]; v != "" {
+		if plain, err := crypto.DecryptToken(v); err == nil {
+			cfg.telegramToken = plain
+		}
+	}
+	cfg.telegramChatID = s["notifications_telegram_chat_id"]
+	return cfg, nil
+}
+
+type ownerNotifConfig struct {
+	discordURL     string
+	telegramToken  string
+	telegramChatID string
+}
+
+func loadOwnerConfig(db *sql.DB, userID string) (ownerNotifConfig, error) {
+	var webhook, token, chatID sql.NullString
+	err := db.QueryRow(
+		`SELECT notification_discord_webhook, notification_telegram_token, notification_telegram_chat_id FROM user WHERE id=?`,
+		userID,
+	).Scan(&webhook, &token, &chatID)
+	if err != nil {
+		return ownerNotifConfig{}, err
+	}
+	var c ownerNotifConfig
+	if webhook.Valid && webhook.String != "" {
+		if plain, err := crypto.DecryptToken(webhook.String); err == nil {
+			c.discordURL = plain
+		}
+	}
+	if token.Valid && token.String != "" {
+		if plain, err := crypto.DecryptToken(token.String); err == nil {
+			c.telegramToken = plain
+		}
+	}
+	if chatID.Valid {
+		c.telegramChatID = chatID.String
+	}
+	return c, nil
+}
+
+func notifyServerStatus(db *sql.DB, serverID, serverName, uuid, ownerID, state string) {
+	if state != "running" && state != "offline" {
+		return
+	}
+	cfg, err := loadNotifConfig(db)
+	if err != nil {
+		log.Printf("[status] failed to load notification config: %v", err)
+		return
+	}
+	label := "online"
+	title := "Server online"
+	if state == "offline" {
+		label = "offline"
+		title = "Server offline"
+	}
+	short := uuid
+	if len(short) > 8 {
+		short = short[:8]
+	}
+	msg := fmt.Sprintf("[%s] Server %q (%s) is now %s", cfg.appName, serverName, short, label)
+	n := notifMessage{
+		title:       title,
+		subtitle:    fmt.Sprintf("%s is now %s.", serverName, label),
+		detail:      fmt.Sprintf("**%s** · %s", serverName, short),
+		buttonLabel: "View server",
+	}
+	if cfg.appURL != "" {
+		n.buttonURL = cfg.appURL + "/servers/" + uuid
+	}
+
+	if cfg.discordEnabled && cfg.discordURL != "" {
+		if err := postDiscord(cfg.discordURL, n); err != nil {
+			log.Printf("[status] discord notify failed for server %s: %v", serverID, err)
+		}
+	}
+	if cfg.telegramEnabled && cfg.telegramToken != "" && cfg.telegramChatID != "" {
+		if err := postTelegram(cfg.telegramToken, cfg.telegramChatID, msg); err != nil {
+			log.Printf("[status] telegram notify failed for server %s: %v", serverID, err)
+		}
+	}
+
+	if ownerID == "" || !cfg.userConfigEnabled {
+		return
+	}
+	oc, err := loadOwnerConfig(db, ownerID)
+	if err != nil {
+		log.Printf("[status] failed to load owner notification config for %s: %v", ownerID, err)
+		return
+	}
+	if oc.discordURL != "" {
+		if err := postDiscord(oc.discordURL, n); err != nil {
+			log.Printf("[status] discord notify failed for owner %s: %v", ownerID, err)
+		}
+	}
+	if oc.telegramToken != "" && oc.telegramChatID != "" {
+		if err := postTelegram(oc.telegramToken, oc.telegramChatID, msg); err != nil {
+			log.Printf("[status] telegram notify failed for owner %s: %v", ownerID, err)
+		}
+	}
+}
+
+type notifMessage struct {
+	title       string
+	subtitle    string
+	detail      string
+	buttonLabel string
+	buttonURL   string
+}
+
+func postDiscord(url string, v notifMessage) error {
+	header := fmt.Sprintf("### ✦ %s\n%s", v.title, v.subtitle)
+	inner := []any{}
+	if v.buttonURL != "" {
+		inner = append(inner,
+			map[string]any{
+				"type": 9,
+				"components": []any{
+					map[string]any{"type": 10, "content": header},
+				},
+				"accessory": map[string]any{"type": 2, "style": 5, "label": v.buttonLabel, "url": v.buttonURL},
+			},
+			map[string]any{"type": 14, "divider": true, "spacing": 1},
+		)
+	} else {
+		inner = append(inner, map[string]any{"type": 10, "content": header})
+	}
+	inner = append(inner,
+		map[string]any{"type": 10, "content": v.detail},
+		map[string]any{"type": 10, "content": fmt.Sprintf("-# <t:%d:R>", time.Now().Unix())},
+	)
+	payload := map[string]any{
+		"flags": 32768,
+		"components": []any{
+			map[string]any{"type": 17, "accent_color": nil, "components": inner},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return httpPostJSON(withComponentsParam(url), data)
+}
+
+func withComponentsParam(url string) string {
+	if strings.Contains(url, "?") {
+		return url + "&with_components=true"
+	}
+	return url + "?with_components=true"
+}
+
+func postTelegram(token, chatID, text string) error {
+	body, _ := json.Marshal(map[string]string{"chat_id": chatID, "text": text})
+	return httpPostJSON(fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", token), body)
+}
+
+func httpPostJSON(url string, body []byte) error {
+	client := &http.Client{Timeout: notifyHTTPTimeout}
+	resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("http %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/apps/watchkeeper/internal/workers/status.go
+++ b/apps/watchkeeper/internal/workers/status.go
@@ -67,10 +67,12 @@ type serverRow struct {
 	uuid       string
 	status     string
 	powerState sql.NullString
+	name       string
+	userId     sql.NullString
 }
 
 func fetchServers(db *sql.DB, nodeID string) ([]serverRow, error) {
-	rows, err := db.Query(`SELECT id, uuid, status, power_state FROM servers WHERE node_id=?`, nodeID)
+	rows, err := db.Query(`SELECT id, uuid, status, power_state, name, user_id FROM servers WHERE node_id=?`, nodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +80,7 @@ func fetchServers(db *sql.DB, nodeID string) ([]serverRow, error) {
 	var out []serverRow
 	for rows.Next() {
 		var s serverRow
-		if err := rows.Scan(&s.id, &s.uuid, &s.status, &s.powerState); err != nil {
+		if err := rows.Scan(&s.id, &s.uuid, &s.status, &s.powerState, &s.name, &s.userId); err != nil {
 			return nil, err
 		}
 		out = append(out, s)
@@ -120,6 +122,8 @@ func processNode(db *sql.DB, node nodeRow) {
 		}
 		if _, err := db.Exec(`UPDATE servers SET power_state=? WHERE id=?`, state, srv.id); err != nil {
 			log.Printf("[status] failed to update server %s: %v", srv.uuid, err)
+			continue
 		}
+		go notifyServerStatus(db, srv.id, srv.name, srv.uuid, srv.userId.String, state)
 	}
 }

--- a/apps/watchkeeper/internal/workers/status.go
+++ b/apps/watchkeeper/internal/workers/status.go
@@ -14,6 +14,8 @@ const statusInterval = 30 * time.Second
 
 func RunStatusWorker(db *sql.DB) {
 	log.Println("[status] worker started, polling every 30s")
+	go runStatusNotifyDispatcher(db)
+	go runStatusNotifyDispatcher(db)
 	statusTick(db)
 	for range time.Tick(statusInterval) {
 		statusTick(db)
@@ -124,6 +126,6 @@ func processNode(db *sql.DB, node nodeRow) {
 			log.Printf("[status] failed to update server %s: %v", srv.uuid, err)
 			continue
 		}
-		go notifyServerStatus(db, srv.id, srv.name, srv.uuid, srv.userId.String, state)
+		enqueueStatusNotify(statusNotifyJob{serverID: srv.id, serverName: srv.name, uuid: srv.uuid, ownerID: srv.userId.String, state: state})
 	}
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -752,7 +752,25 @@
     "tabs": {
       "profile": "Profile",
       "apiKeys": "API Keys",
-      "billing": "Billing"
+      "billing": "Billing",
+      "notifications": "Notifications"
+    },
+    "notifications": {
+      "discordTitle": "Discord",
+      "discordDesc": "Get notified about your servers' power, backup, and status events in a Discord channel.",
+      "discordUrlLabel": "Webhook URL",
+      "discordUrlPlaceholder": "https://discord.com/api/webhooks/…",
+      "telegramTitle": "Telegram",
+      "telegramDesc": "Get notified about your servers' events via a Telegram bot.",
+      "telegramTokenLabel": "Bot Token",
+      "telegramTokenPlaceholder": "1234567890:ABC…",
+      "telegramChatIdLabel": "Chat ID",
+      "telegramChatIdPlaceholder": "123456789",
+      "secretSet": "••••••••  (already set)",
+      "test": "Send Test",
+      "testing": "Sending…",
+      "testSuccess": "Test notification sent",
+      "testFailed": "Failed: {error}"
     },
     "profile": {
       "personalInfoTitle": "Personal Information",
@@ -1581,7 +1599,24 @@
       "gdriveDesc": "Allow users to save backups to their personal Google Drive. Create a Google Cloud project, enable the Drive API, and paste the OAuth client credentials below. While your app is in testing mode, add each user's email as a test user.",
       "gdriveClientIdLabel": "Client ID",
       "gdriveClientIdPlaceholder": "1234567890-abc.apps.googleusercontent.com",
-      "gdriveClientSecretLabel": "Client Secret"
+      "gdriveClientSecretLabel": "Client Secret",
+      "tabNotifications": "Notifications",
+      "notifEndpointsTitle": "Notification Endpoints",
+      "notifEndpointsDesc": "Outbound endpoints for admin notifications about user signups and server/user changes.",
+      "notifDiscordUrlLabel": "Webhook URL",
+      "notifDiscordUrlPlaceholder": "https://discord.com/api/webhooks/…",
+      "notifTelegramTokenLabel": "Bot Token",
+      "notifTelegramTokenPlaceholder": "1234567890:ABC…",
+      "notifTelegramChatIdLabel": "Chat ID",
+      "notifTelegramChatIdPlaceholder": "123456789",
+      "notifUserConfigTitle": "User Notifications",
+      "notifUserConfigDesc": "Allow users to configure their own Discord/Telegram notifications for their servers in account settings.",
+      "notifUserConfigEnabled": "Allow users to set up their own notifications",
+      "notifUserConfigEnabledDesc": "When disabled, users cannot save or receive user-level notifications.",
+      "notifTest": "Send Test",
+      "notifTesting": "Sending…",
+      "notifTestSuccess": "Test notification sent",
+      "notifTestFailed": "Failed: {error}"
     },
     "backupDestinations": {
       "typeLabel": "Destination Type",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -770,7 +770,8 @@
       "test": "Send Test",
       "testing": "Sending…",
       "testSuccess": "Test notification sent",
-      "testFailed": "Failed: {error}"
+      "testFailed": "Failed: {error}",
+      "saveFailed": "Failed to save: {error}"
     },
     "profile": {
       "personalInfoTitle": "Personal Information",
@@ -1616,7 +1617,8 @@
       "notifTest": "Send Test",
       "notifTesting": "Sending…",
       "notifTestSuccess": "Test notification sent",
-      "notifTestFailed": "Failed: {error}"
+      "notifTestFailed": "Failed: {error}",
+      "notifSaveFailed": "Failed to save: {error}"
     },
     "backupDestinations": {
       "typeLabel": "Destination Type",

--- a/apps/web/src/app/(admin)/admin/settings/page.tsx
+++ b/apps/web/src/app/(admin)/admin/settings/page.tsx
@@ -13,6 +13,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@
 import { BackupDestinationForm, defaultBackupDestination } from "@/components/backup-destination-form";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import type { BackupDestinationInput } from "@struxa/api/lib/backup-destinations";
+import { SENTINEL } from "@struxa/api/lib/notification-constants";
 
 function invalidateSettings() {
   void queryClient.invalidateQueries({ queryKey: orpc.settings.key() });
@@ -362,37 +363,53 @@ export default function AdminSettingsPage() {
 
   async function saveDiscordNotifications() {
     if (!notif) return;
-    await saveNotifMutation.mutateAsync({
-      discordEnabled: notif.discordEnabled,
-      discordWebhookUrl: notif.discordWebhookUrl || (notifData?.discordWebhookSet ? "[set]" : ""),
-    });
-    setNotif((prev) => (prev ? { ...prev, discordWebhookUrl: "" } : null));
-    toast.success(tc("saved"));
+    try {
+      await saveNotifMutation.mutateAsync({
+        discordEnabled: notif.discordEnabled,
+        discordWebhookUrl: notif.discordWebhookUrl || (notifData?.discordWebhookSet ? SENTINEL : ""),
+      });
+      setNotif((prev) => (prev ? { ...prev, discordWebhookUrl: "" } : null));
+      toast.success(tc("saved"));
+    } catch (err) {
+      toast.error(t("notifSaveFailed", { error: err instanceof Error ? err.message : "" }));
+    }
   }
 
   async function saveTelegramNotifications() {
     if (!notif) return;
-    await saveNotifMutation.mutateAsync({
-      telegramEnabled: notif.telegramEnabled,
-      telegramBotToken: notif.telegramBotToken || (notifData?.telegramTokenSet ? "[set]" : ""),
-      telegramChatId: notif.telegramChatId,
-    });
-    setNotif((prev) => (prev ? { ...prev, telegramBotToken: "" } : null));
-    toast.success(tc("saved"));
+    try {
+      await saveNotifMutation.mutateAsync({
+        telegramEnabled: notif.telegramEnabled,
+        telegramBotToken: notif.telegramBotToken || (notifData?.telegramTokenSet ? SENTINEL : ""),
+        telegramChatId: notif.telegramChatId,
+      });
+      setNotif((prev) => (prev ? { ...prev, telegramBotToken: "" } : null));
+      toast.success(tc("saved"));
+    } catch (err) {
+      toast.error(t("notifSaveFailed", { error: err instanceof Error ? err.message : "" }));
+    }
   }
 
   async function saveUserConfigNotifications() {
     if (!notif) return;
-    await saveNotifMutation.mutateAsync({
-      userConfigEnabled: notif.userConfigEnabled,
-    });
-    toast.success(tc("saved"));
+    try {
+      await saveNotifMutation.mutateAsync({
+        userConfigEnabled: notif.userConfigEnabled,
+      });
+      toast.success(tc("saved"));
+    } catch (err) {
+      toast.error(t("notifSaveFailed", { error: err instanceof Error ? err.message : "" }));
+    }
   }
 
   async function testNotification(channel: "discord" | "telegram") {
-    const result = await testNotifMutation.mutateAsync({ channel });
-    if (result.ok) toast.success(t("notifTestSuccess"));
-    else toast.error(t("notifTestFailed", { error: result.error ?? "" }));
+    try {
+      const result = await testNotifMutation.mutateAsync({ channel });
+      if (result.ok) toast.success(t("notifTestSuccess"));
+      else toast.error(t("notifTestFailed", { error: result.error ?? "" }));
+    } catch (err) {
+      toast.error(t("notifTestFailed", { error: err instanceof Error ? err.message : "" }));
+    }
   }
 
   function generalForm() {
@@ -537,7 +554,7 @@ export default function AdminSettingsPage() {
   if (isLoading) {
     return (
       <div className="flex flex-1 items-center justify-center">
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <p className="text-sm text-muted-foreground">{tc("loading")}</p>
       </div>
     );
   }
@@ -973,7 +990,7 @@ export default function AdminSettingsPage() {
           <>
             <SectionCard title={t("smtpTitle")} description={t("smtpDesc")}>
               {smtpLoading || !smtp ? (
-                <div className="py-4 text-center text-xs text-muted-foreground">Loading…</div>
+                <div className="py-4 text-center text-xs text-muted-foreground">{tc("loading")}</div>
               ) : (
                 <div className="flex flex-col gap-4">
                   {/* Enable toggle */}
@@ -1114,7 +1131,7 @@ export default function AdminSettingsPage() {
           <>
             <SectionCard title={t("backupsGlobalTitle")} description={t("backupsGlobalDesc")}>
               {globalDestinationLoading ? (
-                <div className="py-4 text-center text-xs text-muted-foreground">Loading…</div>
+                <div className="py-4 text-center text-xs text-muted-foreground">{tc("loading")}</div>
               ) : (
                 <div className="flex flex-col gap-4">
                   {!globalDestination && (
@@ -1190,7 +1207,7 @@ export default function AdminSettingsPage() {
           <>
             <SectionCard title={t("notifEndpointsTitle")} description={t("notifEndpointsDesc")}>
               {notifLoading || !notif ? (
-                <div className="py-4 text-center text-xs text-muted-foreground">Loading…</div>
+                <div className="py-4 text-center text-xs text-muted-foreground">{tc("loading")}</div>
               ) : (
                 <div className="flex flex-col gap-2">
                   <NotificationEndpointRow
@@ -1287,7 +1304,7 @@ export default function AdminSettingsPage() {
 
             <SectionCard title={t("notifUserConfigTitle")} description={t("notifUserConfigDesc")}>
               {notifLoading || !notif ? (
-                <div className="py-4 text-center text-xs text-muted-foreground">Loading…</div>
+                <div className="py-4 text-center text-xs text-muted-foreground">{tc("loading")}</div>
               ) : (
                 <div className="flex flex-col gap-4">
                   <div className="flex items-center justify-between">

--- a/apps/web/src/app/(admin)/admin/settings/page.tsx
+++ b/apps/web/src/app/(admin)/admin/settings/page.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, useEffect } from "react";
 import { motion } from "motion/react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { Check, Upload, X, Github, ChevronDown, RotateCcw, Copy, Mail, Loader2, ChevronRight } from "lucide-react";
+import { Check, Upload, X, Github, ChevronDown, RotateCcw, Copy, Mail, Loader2, ChevronRight, Send } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 import { orpc, queryClient } from "@/utils/orpc";
@@ -193,7 +193,49 @@ function DiscordIcon({ className }: { className?: string }) {
   );
 }
 
-const TABS = ["branding", "seo", "auth", "email", "backups"] as const;
+function NotificationEndpointRow({
+  icon,
+  name,
+  enabled,
+  onToggle,
+  expanded,
+  onExpandToggle,
+  children,
+}: {
+  icon: React.ReactNode;
+  name: string;
+  enabled: boolean;
+  onToggle: (v: boolean) => void;
+  expanded: boolean;
+  onExpandToggle: () => void;
+  children: React.ReactNode;
+}) {
+  const t = useTranslations("admin.settings");
+  return (
+    <div className="rounded-lg border border-border overflow-hidden">
+      <button
+        type="button"
+        onClick={onExpandToggle}
+        className="flex w-full items-center justify-between px-4 py-3 hover:bg-muted/50 transition-colors"
+      >
+        <div className="flex items-center gap-2.5">
+          {icon}
+          <span className="text-sm font-medium text-foreground">{name}</span>
+          {enabled && (
+            <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[11px] font-medium text-green-600 dark:text-green-400">{t("enabled")}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Toggle enabled={enabled} onChange={onToggle} />
+          <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform ${expanded ? "rotate-180" : ""}`} />
+        </div>
+      </button>
+      {expanded && <div className="border-t border-border px-4 py-4">{children}</div>}
+    </div>
+  );
+}
+
+const TABS = ["branding", "seo", "auth", "email", "backups", "notifications"] as const;
 type Tab = (typeof TABS)[number];
 
 export default function AdminSettingsPage() {
@@ -288,6 +330,69 @@ export default function AdminSettingsPage() {
     await clearGlobalDestinationMutation.mutateAsync(undefined);
     setBackupDestination(null);
     setBackupResetOpen(false);
+  }
+
+  const { data: notifData, isLoading: notifLoading } = useQuery(orpc.notifications.getAdminConfig.queryOptions());
+  const saveNotifMutation = useMutation(orpc.notifications.saveAdminConfig.mutationOptions({
+    onSuccess: () => { void queryClient.invalidateQueries({ queryKey: orpc.notifications.key() }); },
+  }));
+  const testNotifMutation = useMutation(orpc.notifications.test.mutationOptions());
+  const [notif, setNotif] = useState<{
+    discordEnabled: boolean;
+    discordWebhookUrl: string;
+    telegramEnabled: boolean;
+    telegramBotToken: string;
+    telegramChatId: string;
+    userConfigEnabled: boolean;
+  } | null>(null);
+  const [discordNotifExpanded, setDiscordNotifExpanded] = useState(false);
+  const [telegramNotifExpanded, setTelegramNotifExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!notifData || notif !== null) return;
+    setNotif({
+      discordEnabled: notifData.discordEnabled,
+      discordWebhookUrl: "",
+      telegramEnabled: notifData.telegramEnabled,
+      telegramBotToken: "",
+      telegramChatId: notifData.telegramChatId,
+      userConfigEnabled: notifData.userConfigEnabled,
+    });
+  }, [notifData, notif]);
+
+  async function saveDiscordNotifications() {
+    if (!notif) return;
+    await saveNotifMutation.mutateAsync({
+      discordEnabled: notif.discordEnabled,
+      discordWebhookUrl: notif.discordWebhookUrl || (notifData?.discordWebhookSet ? "[set]" : ""),
+    });
+    setNotif((prev) => (prev ? { ...prev, discordWebhookUrl: "" } : null));
+    toast.success(tc("saved"));
+  }
+
+  async function saveTelegramNotifications() {
+    if (!notif) return;
+    await saveNotifMutation.mutateAsync({
+      telegramEnabled: notif.telegramEnabled,
+      telegramBotToken: notif.telegramBotToken || (notifData?.telegramTokenSet ? "[set]" : ""),
+      telegramChatId: notif.telegramChatId,
+    });
+    setNotif((prev) => (prev ? { ...prev, telegramBotToken: "" } : null));
+    toast.success(tc("saved"));
+  }
+
+  async function saveUserConfigNotifications() {
+    if (!notif) return;
+    await saveNotifMutation.mutateAsync({
+      userConfigEnabled: notif.userConfigEnabled,
+    });
+    toast.success(tc("saved"));
+  }
+
+  async function testNotification(channel: "discord" | "telegram") {
+    const result = await testNotifMutation.mutateAsync({ channel });
+    if (result.ok) toast.success(t("notifTestSuccess"));
+    else toast.error(t("notifTestFailed", { error: result.error ?? "" }));
   }
 
   function generalForm() {
@@ -463,7 +568,8 @@ export default function AdminSettingsPage() {
                 : tab_item === "seo" ? t("tabSeo")
                 : tab_item === "auth" ? t("tabAuth")
                 : tab_item === "email" ? t("tabEmail")
-                : t("tabBackups")}
+                : tab_item === "backups" ? t("tabBackups")
+                : t("tabNotifications")}
             </button>
           ))}
         </div>
@@ -1077,6 +1183,126 @@ export default function AdminSettingsPage() {
               loading={clearGlobalDestinationMutation.isPending}
               onConfirm={resetBackupDestination}
             />
+          </>
+        )}
+
+        {tab === "notifications" && (
+          <>
+            <SectionCard title={t("notifEndpointsTitle")} description={t("notifEndpointsDesc")}>
+              {notifLoading || !notif ? (
+                <div className="py-4 text-center text-xs text-muted-foreground">Loading…</div>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  <NotificationEndpointRow
+                    icon={<DiscordIcon className="h-4 w-4 text-[#5865F2]" />}
+                    name="Discord"
+                    enabled={notif.discordEnabled}
+                    onToggle={(v) => setNotif({ ...notif, discordEnabled: v })}
+                    expanded={discordNotifExpanded}
+                    onExpandToggle={() => setDiscordNotifExpanded((v) => !v)}
+                  >
+                    <div className="flex flex-col gap-4">
+                      <div className="flex flex-col gap-1.5">
+                        <label className="text-xs font-medium text-foreground">{t("notifDiscordUrlLabel")}</label>
+                        <input
+                          className={inputClass()}
+                          type="password"
+                          placeholder={notifData?.discordWebhookSet ? t("clientSecretSet") : t("notifDiscordUrlPlaceholder")}
+                          value={notif.discordWebhookUrl}
+                          onChange={(e) => setNotif({ ...notif, discordWebhookUrl: e.target.value })}
+                          autoComplete="new-password"
+                        />
+                      </div>
+                      <div className="flex items-center gap-3 flex-wrap">
+                        <div onClick={saveDiscordNotifications}>
+                          <SaveButton saving={saveNotifMutation.isPending} />
+                        </div>
+                        <button
+                          type="button"
+                          disabled={testNotifMutation.isPending}
+                          onClick={() => testNotification("discord")}
+                          className="flex items-center gap-1.5 rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+                        >
+                          {testNotifMutation.isPending ? (
+                            <><Loader2 className="h-3.5 w-3.5 animate-spin" /> {t("notifTesting")}</>
+                          ) : (
+                            <><Mail className="h-3.5 w-3.5" /> {t("notifTest")}</>
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  </NotificationEndpointRow>
+
+                  <NotificationEndpointRow
+                    icon={<Send className="h-4 w-4 text-[#26A5E4]" />}
+                    name="Telegram"
+                    enabled={notif.telegramEnabled}
+                    onToggle={(v) => setNotif({ ...notif, telegramEnabled: v })}
+                    expanded={telegramNotifExpanded}
+                    onExpandToggle={() => setTelegramNotifExpanded((v) => !v)}
+                  >
+                    <div className="flex flex-col gap-4">
+                      <div className="flex flex-col gap-1.5">
+                        <label className="text-xs font-medium text-foreground">{t("notifTelegramTokenLabel")}</label>
+                        <input
+                          className={inputClass()}
+                          type="password"
+                          placeholder={notifData?.telegramTokenSet ? t("clientSecretSet") : t("notifTelegramTokenPlaceholder")}
+                          value={notif.telegramBotToken}
+                          onChange={(e) => setNotif({ ...notif, telegramBotToken: e.target.value })}
+                          autoComplete="new-password"
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        <label className="text-xs font-medium text-foreground">{t("notifTelegramChatIdLabel")}</label>
+                        <input
+                          className={inputClass()}
+                          placeholder={t("notifTelegramChatIdPlaceholder")}
+                          value={notif.telegramChatId}
+                          onChange={(e) => setNotif({ ...notif, telegramChatId: e.target.value })}
+                        />
+                      </div>
+                      <div className="flex items-center gap-3 flex-wrap">
+                        <div onClick={saveTelegramNotifications}>
+                          <SaveButton saving={saveNotifMutation.isPending} />
+                        </div>
+                        <button
+                          type="button"
+                          disabled={testNotifMutation.isPending}
+                          onClick={() => testNotification("telegram")}
+                          className="flex items-center gap-1.5 rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+                        >
+                          {testNotifMutation.isPending ? (
+                            <><Loader2 className="h-3.5 w-3.5 animate-spin" /> {t("notifTesting")}</>
+                          ) : (
+                            <><Mail className="h-3.5 w-3.5" /> {t("notifTest")}</>
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  </NotificationEndpointRow>
+                </div>
+              )}
+            </SectionCard>
+
+            <SectionCard title={t("notifUserConfigTitle")} description={t("notifUserConfigDesc")}>
+              {notifLoading || !notif ? (
+                <div className="py-4 text-center text-xs text-muted-foreground">Loading…</div>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{t("notifUserConfigEnabled")}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">{t("notifUserConfigEnabledDesc")}</p>
+                    </div>
+                    <Toggle enabled={notif.userConfigEnabled} onChange={(v) => setNotif({ ...notif, userConfigEnabled: v })} />
+                  </div>
+                  <div onClick={saveUserConfigNotifications}>
+                    <SaveButton saving={saveNotifMutation.isPending} />
+                  </div>
+                </div>
+              )}
+            </SectionCard>
           </>
         )}
         </motion.div>

--- a/apps/web/src/app/(panel)/account/page.tsx
+++ b/apps/web/src/app/(panel)/account/page.tsx
@@ -24,7 +24,7 @@ import { toast } from "sonner";
 import { DitherAvatar } from "@struxa/ui/components/dither-kit/avatar";
 import { GoogleIcon } from "@/components/google-icon";
 
-type Tab = "profile" | "api-keys" | "billing";
+type Tab = "profile" | "api-keys" | "billing" | "notifications";
 
 const COUNTRIES = [
   { code: "US", name: "United States" },
@@ -1475,16 +1475,158 @@ function BillingTab() {
 }
 
 // ─────────────────────────────────────────────
+// Notifications Tab
+// ─────────────────────────────────────────────
+function NotificationsTab() {
+  const t = useTranslations("account.notifications");
+  const tc = useTranslations("common");
+  const { data: cfg, isLoading } = useQuery(orpc.notifications.getUserConfig.queryOptions());
+
+  const [form, setForm] = useState({
+    discordWebhookUrl: "",
+    telegramBotToken: "",
+    telegramChatId: "",
+  });
+
+  useEffect(() => {
+    if (!cfg || !cfg.enabled) return;
+    setForm((prev) => (prev.telegramChatId ? prev : { ...prev, telegramChatId: cfg.telegramChatId }));
+  }, [cfg]);
+
+  const saveMutation = useMutation(
+    orpc.notifications.saveUserConfig.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({ queryKey: orpc.notifications.key() });
+        toast.success(tc("saved"));
+      },
+    }),
+  );
+  const testMutation = useMutation(orpc.notifications.testUser.mutationOptions());
+
+  if (isLoading) return <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>;
+
+  if (!cfg?.enabled) return null;
+
+  const saveDiscord = () => {
+    saveMutation.mutate({
+      discordWebhookUrl: form.discordWebhookUrl || (cfg.discordWebhookSet ? "[set]" : ""),
+    });
+    setForm((prev) => ({ ...prev, discordWebhookUrl: "" }));
+  };
+
+  const saveTelegram = () => {
+    saveMutation.mutate({
+      telegramBotToken: form.telegramBotToken || (cfg.telegramTokenSet ? "[set]" : ""),
+      telegramChatId: form.telegramChatId,
+    });
+    setForm((prev) => ({ ...prev, telegramBotToken: "" }));
+  };
+
+  async function testChannel(channel: "discord" | "telegram") {
+    const result = await testMutation.mutateAsync({ channel });
+    if (result.ok) toast.success(t("testSuccess"));
+    else toast.error(t("testFailed", { error: result.error ?? "" }));
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionCard title={t("discordTitle")} description={t("discordDesc")}>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-foreground">{t("discordUrlLabel")}</label>
+            <input
+              className={inputClass(true)}
+              type="password"
+              placeholder={cfg.discordWebhookSet ? t("secretSet") : t("discordUrlPlaceholder")}
+              value={form.discordWebhookUrl}
+              onChange={(e) => setForm({ ...form, discordWebhookUrl: e.target.value })}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={saveMutation.isPending}
+              onClick={saveDiscord}
+              className="rounded-lg bg-foreground px-4 py-1.5 text-sm font-medium text-background transition-opacity hover:opacity-80 disabled:opacity-40"
+            >
+              {saveMutation.isPending ? tc("saving") : tc("save")}
+            </button>
+            <button
+              type="button"
+              disabled={testMutation.isPending}
+              onClick={() => testChannel("discord")}
+              className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+            >
+              {testMutation.isPending ? t("testing") : t("test")}
+            </button>
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title={t("telegramTitle")} description={t("telegramDesc")}>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-foreground">{t("telegramTokenLabel")}</label>
+            <input
+              className={inputClass(true)}
+              type="password"
+              placeholder={cfg.telegramTokenSet ? t("secretSet") : t("telegramTokenPlaceholder")}
+              value={form.telegramBotToken}
+              onChange={(e) => setForm({ ...form, telegramBotToken: e.target.value })}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-foreground">{t("telegramChatIdLabel")}</label>
+            <input
+              className={inputClass(true)}
+              placeholder={t("telegramChatIdPlaceholder")}
+              value={form.telegramChatId}
+              onChange={(e) => setForm({ ...form, telegramChatId: e.target.value })}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={saveMutation.isPending}
+              onClick={saveTelegram}
+              className="rounded-lg bg-foreground px-4 py-1.5 text-sm font-medium text-background transition-opacity hover:opacity-80 disabled:opacity-40"
+            >
+              {saveMutation.isPending ? tc("saving") : tc("save")}
+            </button>
+            <button
+              type="button"
+              disabled={testMutation.isPending}
+              onClick={() => testChannel("telegram")}
+              className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+            >
+              {testMutation.isPending ? t("testing") : t("test")}
+            </button>
+          </div>
+        </div>
+      </SectionCard>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
 // Page
 // ─────────────────────────────────────────────
 export default function AccountPage() {
   const t = useTranslations("account.tabs");
   const [tab, setTab] = useState<Tab>("profile");
+  const { data: notifCfg } = useQuery(orpc.notifications.getUserConfig.queryOptions());
+
+  useEffect(() => {
+    if (!notifCfg?.enabled && tab === "notifications") setTab("profile");
+  }, [notifCfg, tab]);
 
   const TABS: { id: Tab; label: string }[] = [
     { id: "profile", label: t("profile") },
     { id: "api-keys", label: t("apiKeys") },
     { id: "billing", label: t("billing") },
+    ...(notifCfg?.enabled ? [{ id: "notifications" as Tab, label: t("notifications") }] : []),
   ];
 
   return (
@@ -1517,6 +1659,7 @@ export default function AccountPage() {
             {tab === "profile" && <ProfileTab />}
             {tab === "api-keys" && <ApiKeysTab />}
             {tab === "billing" && <BillingTab />}
+            {tab === "notifications" && <NotificationsTab />}
           </motion.div>
         </div>
       </div>

--- a/apps/web/src/app/(panel)/account/page.tsx
+++ b/apps/web/src/app/(panel)/account/page.tsx
@@ -23,6 +23,7 @@ import { orpc, queryClient } from "@/utils/orpc";
 import { toast } from "sonner";
 import { DitherAvatar } from "@struxa/ui/components/dither-kit/avatar";
 import { GoogleIcon } from "@/components/google-icon";
+import { SENTINEL } from "@struxa/api/lib/notification-constants";
 
 type Tab = "profile" | "api-keys" | "billing" | "notifications";
 
@@ -1499,33 +1500,40 @@ function NotificationsTab() {
         void queryClient.invalidateQueries({ queryKey: orpc.notifications.key() });
         toast.success(tc("saved"));
       },
+      onError: (error) => {
+        toast.error(t("saveFailed", { error: error instanceof Error ? error.message : "" }));
+      },
     }),
   );
   const testMutation = useMutation(orpc.notifications.testUser.mutationOptions());
 
-  if (isLoading) return <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>;
+  if (isLoading) return <div className="py-8 text-center text-sm text-muted-foreground">{tc("loading")}</div>;
 
   if (!cfg?.enabled) return null;
 
   const saveDiscord = () => {
     saveMutation.mutate({
-      discordWebhookUrl: form.discordWebhookUrl || (cfg.discordWebhookSet ? "[set]" : ""),
+      discordWebhookUrl: form.discordWebhookUrl || (cfg.discordWebhookSet ? SENTINEL : ""),
     });
     setForm((prev) => ({ ...prev, discordWebhookUrl: "" }));
   };
 
   const saveTelegram = () => {
     saveMutation.mutate({
-      telegramBotToken: form.telegramBotToken || (cfg.telegramTokenSet ? "[set]" : ""),
+      telegramBotToken: form.telegramBotToken || (cfg.telegramTokenSet ? SENTINEL : ""),
       telegramChatId: form.telegramChatId,
     });
     setForm((prev) => ({ ...prev, telegramBotToken: "" }));
   };
 
   async function testChannel(channel: "discord" | "telegram") {
-    const result = await testMutation.mutateAsync({ channel });
-    if (result.ok) toast.success(t("testSuccess"));
-    else toast.error(t("testFailed", { error: result.error ?? "" }));
+    try {
+      const result = await testMutation.mutateAsync({ channel });
+      if (result.ok) toast.success(t("testSuccess"));
+      else toast.error(t("testFailed", { error: result.error ?? "" }));
+    } catch (err) {
+      toast.error(t("testFailed", { error: err instanceof Error ? err.message : "" }));
+    }
   }
 
   return (

--- a/apps/web/src/app/api/billing/webhook/[provider]/route.ts
+++ b/apps/web/src/app/api/billing/webhook/[provider]/route.ts
@@ -10,6 +10,7 @@ import {
   settings,
 } from "@struxa/db";
 import { decrypt } from "@struxa/api/lib/crypto";
+import { notifyAdmins } from "@struxa/api/services/notifications";
 import { handleWebhook } from "@struxa/payments";
 import type { WebhookPayload } from "@struxa/payments";
 import { randomUUID } from "crypto";
@@ -157,6 +158,9 @@ export async function POST(
 
   if (payload?.type === "topup.succeeded") {
     await creditWallet(payload, gateway.provider);
+    notifyAdmins("payment", { result: "received", amount: (payload.amountCents / 100).toFixed(2), currency: payload.currency.toUpperCase(), provider: gateway.provider });
+  } else if (payload?.type === "topup.failed") {
+    notifyAdmins("payment", { result: "failed", provider: gateway.provider });
   }
 
   return new Response("OK", { status: 200 });

--- a/apps/web/src/app/api/billing/webhook/[provider]/route.ts
+++ b/apps/web/src/app/api/billing/webhook/[provider]/route.ts
@@ -41,7 +41,7 @@ async function addWalletCredits(
   });
 }
 
-async function creditWallet(payload: Extract<WebhookPayload, { type: "topup.succeeded" }>, gatewayProvider: string) {
+async function creditWallet(payload: Extract<WebhookPayload, { type: "topup.succeeded" }>, gatewayProvider: string): Promise<boolean> {
   try {
     await db.transaction(async (tx) => {
       const walletRow = await tx.query.billingWallet.findFirst({ where: eq(billingWallet.userId, payload.userId) });
@@ -114,10 +114,11 @@ async function creditWallet(payload: Extract<WebhookPayload, { type: "topup.succ
         }
       }
     });
+    return true;
   } catch (err) {
     const sqlErr = err as { code?: string };
     // Unique constraint violation = already processed this webhook
-    if (sqlErr?.code === "ER_DUP_ENTRY") return;
+    if (sqlErr?.code === "ER_DUP_ENTRY") return false;
     throw err;
   }
 }
@@ -157,8 +158,10 @@ export async function POST(
   const payload = await handleWebhook(provider, { rawBody, headers, config, gatewayId: gateway.id, sourceIp });
 
   if (payload?.type === "topup.succeeded") {
-    await creditWallet(payload, gateway.provider);
-    notifyAdmins("payment", { result: "received", amount: (payload.amountCents / 100).toFixed(2), currency: payload.currency.toUpperCase(), provider: gateway.provider });
+    const inserted = await creditWallet(payload, gateway.provider);
+    if (inserted) {
+      notifyAdmins("payment", { result: "received", amount: (payload.amountCents / 100).toFixed(2), currency: payload.currency.toUpperCase(), provider: gateway.provider });
+    }
   } else if (payload?.type === "topup.failed") {
     notifyAdmins("payment", { result: "failed", provider: gateway.provider });
   }

--- a/apps/web/src/app/api/remote/backups/[uuid]/route.ts
+++ b/apps/web/src/app/api/remote/backups/[uuid]/route.ts
@@ -4,6 +4,7 @@ import { db } from "@struxa/db";
 import { backups } from "@struxa/db";
 import { resolveDestinationForNode } from "@struxa/api/lib/backup-destinations";
 import { abortMultipart, completeMultipart } from "@struxa/api/services/backup-s3";
+import { notifyServerOwner } from "@struxa/api/services/notifications";
 import { authenticateWings } from "@/lib/wings-auth";
 import { getBackupWithServer } from "@/lib/remote-backups";
 
@@ -53,6 +54,15 @@ export async function POST(
       remoteFileId: remoteId,
     })
     .where(eq(backups.id, backup.id));
+
+  if (backup.server?.userId) {
+    notifyServerOwner(backup.server.userId, "backup", {
+      backupName: backup.name,
+      serverName: backup.server.name,
+      serverUuid: backup.server.uuid,
+      result: body.successful ? "completed successfully" : "failed",
+    });
+  }
 
   if (backup.disk === "s3") {
     const destination = await resolveDestinationForNode(auth.node.id);

--- a/apps/web/src/app/api/remote/backups/[uuid]/route.ts
+++ b/apps/web/src/app/api/remote/backups/[uuid]/route.ts
@@ -55,15 +55,6 @@ export async function POST(
     })
     .where(eq(backups.id, backup.id));
 
-  if (backup.server?.userId) {
-    notifyServerOwner(backup.server.userId, "backup", {
-      backupName: backup.name,
-      serverName: backup.server.name,
-      serverUuid: backup.server.uuid,
-      result: body.successful ? "completed successfully" : "failed",
-    });
-  }
-
   if (backup.disk === "s3") {
     const destination = await resolveDestinationForNode(auth.node.id);
     if (!destination || destination.type !== "s3") {
@@ -86,6 +77,15 @@ export async function POST(
         status: 500,
       });
     }
+  }
+
+  if (backup.server?.userId) {
+    notifyServerOwner(backup.server.userId, "backup", {
+      backupName: backup.name,
+      serverName: backup.server.name,
+      serverUuid: backup.server.uuid,
+      result: body.successful ? "completed successfully" : "failed",
+    });
   }
 
   return new Response(null, { status: 204 });

--- a/packages/api/src/lib/notification-constants.ts
+++ b/packages/api/src/lib/notification-constants.ts
@@ -1,0 +1,1 @@
+export const SENTINEL = "[set]";

--- a/packages/api/src/routers/backups.ts
+++ b/packages/api/src/routers/backups.ts
@@ -17,6 +17,7 @@ import {
   getOperatorGDriveConfig,
 } from "../services/google-drive";
 import { recordActivity } from "../services/activity";
+import { notifyServerOwner } from "../services/notifications";
 import { protectedProcedure } from "../index";
 
 export const backupsRouter = {
@@ -133,6 +134,7 @@ export const backupsRouter = {
         ip: context.ip,
         properties: { name: input.name },
       });
+      notifyServerOwner(server.userId, "backup", { backupName: input.name, serverName: server.name, serverUuid: server.uuid, result: "started" });
 
       return db.query.backups.findFirst({ where: eq(backups.id, id) });
     }),
@@ -172,6 +174,7 @@ export const backupsRouter = {
         ip: context.ip,
         properties: { name: backup.name },
       });
+      notifyServerOwner(server.userId, "backup", { backupName: backup.name, serverName: server.name, serverUuid: server.uuid, result: "deleted" });
     }),
 
   getDownloadUrl: protectedProcedure
@@ -292,5 +295,6 @@ export const backupsRouter = {
         ip: context.ip,
         properties: { name: backup.name },
       });
+      notifyServerOwner(server.userId, "backup", { backupName: backup.name, serverName: server.name, serverUuid: server.uuid, result: "restore started" });
     }),
 };

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -21,6 +21,7 @@ import { onboardingRouter } from "./onboarding";
 import { emailRouter } from "./email";
 import { billingRouter } from "./billing";
 import { googleDriveRouter } from "./google-drive";
+import { notificationsRouter } from "./notifications";
 
 export const appRouter = {
   healthCheck: publicProcedure.handler(() => {
@@ -46,6 +47,7 @@ export const appRouter = {
   email: emailRouter,
   billing: billingRouter,
   googleDrive: googleDriveRouter,
+  notifications: notificationsRouter,
 };
 
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/routers/notifications.ts
+++ b/packages/api/src/routers/notifications.ts
@@ -1,0 +1,203 @@
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { ORPCError } from "@orpc/server";
+import { db } from "@struxa/db";
+import { settings } from "@struxa/db";
+import { user } from "@struxa/db";
+import { encrypt } from "../lib/crypto";
+import { recordActivity } from "../services/activity";
+import { adminProcedure, protectedProcedure } from "../index";
+import {
+  SENTINEL,
+  buildDiscordComponents,
+  buildMessage,
+  getAdminNotificationConfig,
+  getUserNotificationConfig,
+  isValidDiscordWebhookUrl,
+  isValidTelegramBotToken,
+  isValidTelegramChatId,
+  postDiscord,
+  postTelegram,
+} from "../services/notifications";
+
+async function upsertSetting(key: string, value: string) {
+  await db
+    .insert(settings)
+    .values({ key, value, updatedAt: new Date() })
+    .onDuplicateKeyUpdate({ set: { value, updatedAt: new Date() } });
+}
+
+export const notificationsRouter = {
+  getAdminConfig: adminProcedure.handler(async () => {
+    const rows = await db.select().from(settings);
+    const s = Object.fromEntries(rows.map((r) => [r.key, r.value ?? ""]));
+    return {
+      discordEnabled: s.notifications_discord_enabled === "true",
+      discordWebhookSet: !!s.notifications_discord_webhook_url,
+      telegramEnabled: s.notifications_telegram_enabled === "true",
+      telegramTokenSet: !!s.notifications_telegram_bot_token,
+      telegramChatId: s.notifications_telegram_chat_id ?? "",
+      userConfigEnabled: s.notifications_user_config_enabled === "true",
+    };
+  }),
+
+  saveAdminConfig: adminProcedure
+    .input(
+      z.object({
+        discordEnabled: z.boolean().optional(),
+        discordWebhookUrl: z.string().max(500).optional(),
+        telegramEnabled: z.boolean().optional(),
+        telegramBotToken: z.string().max(300).optional(),
+        telegramChatId: z.string().max(64).optional(),
+        userConfigEnabled: z.boolean().optional(),
+      }),
+    )
+    .handler(async ({ context, input }) => {
+      const pairs: Array<{ key: string; value: string }> = [];
+      if (input.discordEnabled !== undefined) pairs.push({ key: "notifications_discord_enabled", value: String(input.discordEnabled) });
+      if (input.telegramEnabled !== undefined) pairs.push({ key: "notifications_telegram_enabled", value: String(input.telegramEnabled) });
+      if (input.userConfigEnabled !== undefined) pairs.push({ key: "notifications_user_config_enabled", value: String(input.userConfigEnabled) });
+      if (input.discordWebhookUrl !== undefined && input.discordWebhookUrl !== SENTINEL) {
+        if (input.discordWebhookUrl === "") {
+          await db.delete(settings).where(eq(settings.key, "notifications_discord_webhook_url"));
+        } else {
+          if (!isValidDiscordWebhookUrl(input.discordWebhookUrl)) {
+            throw new ORPCError("BAD_REQUEST", { message: "Invalid Discord webhook URL" });
+          }
+          pairs.push({ key: "notifications_discord_webhook_url", value: encrypt(input.discordWebhookUrl) });
+        }
+      }
+      if (input.telegramBotToken !== undefined && input.telegramBotToken !== SENTINEL) {
+        if (input.telegramBotToken === "") {
+          await db.delete(settings).where(eq(settings.key, "notifications_telegram_bot_token"));
+        } else {
+          if (!isValidTelegramBotToken(input.telegramBotToken)) {
+            throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram bot token" });
+          }
+          pairs.push({ key: "notifications_telegram_bot_token", value: encrypt(input.telegramBotToken) });
+        }
+      }
+      if (input.telegramChatId !== undefined && input.telegramChatId !== SENTINEL) {
+        if (!isValidTelegramChatId(input.telegramChatId)) {
+          throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram chat id" });
+        }
+        pairs.push({ key: "notifications_telegram_chat_id", value: input.telegramChatId });
+      }
+      for (const { key, value } of pairs) {
+        await upsertSetting(key, value);
+      }
+      context.revalidate?.();
+      recordActivity({ eventType: "admin:settings.update", userId: context.session.user.id, ip: context.ip, properties: { keys: pairs.map((p) => p.key) } });
+    }),
+
+  test: adminProcedure
+    .input(z.object({ channel: z.enum(["discord", "telegram"]) }))
+    .handler(async ({ input }) => {
+      const cfg = await getAdminNotificationConfig();
+      const message = buildMessage("test", { appName: cfg.appName });
+      try {
+        if (input.channel === "discord") {
+          if (!cfg.discordEnabled || !cfg.discordWebhookUrl) {
+            return { ok: false as const, error: "Discord is not configured or disabled" };
+          }
+          await postDiscord(cfg.discordWebhookUrl, buildDiscordComponents("test", { appName: cfg.appName }));
+        } else {
+          if (!cfg.telegramEnabled || !cfg.telegramToken || !cfg.telegramChatId) {
+            return { ok: false as const, error: "Telegram is not configured or disabled" };
+          }
+          await postTelegram(cfg.telegramToken, cfg.telegramChatId, message);
+        }
+        return { ok: true as const };
+      } catch (err) {
+        return { ok: false as const, error: err instanceof Error ? err.message : "Send failed" };
+      }
+    }),
+
+  getUserConfig: protectedProcedure.handler(async ({ context }) => {
+    const row = await db.query.settings.findFirst({
+      where: eq(settings.key, "notifications_user_config_enabled"),
+    });
+    if (row?.value !== "true") return { enabled: false as const };
+    const me = await db.query.user.findFirst({
+      where: eq(user.id, context.session.user.id),
+    });
+    return {
+      enabled: true as const,
+      discordWebhookSet: !!me?.notificationDiscordWebhook,
+      telegramTokenSet: !!me?.notificationTelegramToken,
+      telegramChatId: me?.notificationTelegramChatId ?? "",
+    };
+  }),
+
+  saveUserConfig: protectedProcedure
+    .input(
+      z.object({
+        discordWebhookUrl: z.string().max(500).optional(),
+        telegramBotToken: z.string().max(300).optional(),
+        telegramChatId: z.string().max(64).optional(),
+      }),
+    )
+    .handler(async ({ context, input }) => {
+      const row = await db.query.settings.findFirst({
+        where: eq(settings.key, "notifications_user_config_enabled"),
+      });
+      if (row?.value !== "true") {
+        throw new ORPCError("FORBIDDEN", { message: "User notifications are disabled" });
+      }
+
+      const updates: Record<string, string | null> = {};
+      if (input.discordWebhookUrl !== undefined && input.discordWebhookUrl !== SENTINEL) {
+        if (input.discordWebhookUrl === "") {
+          updates.notificationDiscordWebhook = null;
+        } else {
+          if (!isValidDiscordWebhookUrl(input.discordWebhookUrl)) {
+            throw new ORPCError("BAD_REQUEST", { message: "Invalid Discord webhook URL" });
+          }
+          updates.notificationDiscordWebhook = encrypt(input.discordWebhookUrl);
+        }
+      }
+      if (input.telegramBotToken !== undefined && input.telegramBotToken !== SENTINEL) {
+        if (input.telegramBotToken === "") {
+          updates.notificationTelegramToken = null;
+        } else {
+          if (!isValidTelegramBotToken(input.telegramBotToken)) {
+            throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram bot token" });
+          }
+          updates.notificationTelegramToken = encrypt(input.telegramBotToken);
+        }
+      }
+      if (input.telegramChatId !== undefined && input.telegramChatId !== SENTINEL) {
+        if (!isValidTelegramChatId(input.telegramChatId)) {
+          throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram chat id" });
+        }
+        updates.notificationTelegramChatId = input.telegramChatId;
+      }
+      if (Object.keys(updates).length > 0) {
+        await db.update(user).set(updates).where(eq(user.id, context.session.user.id));
+      }
+    }),
+
+  testUser: protectedProcedure
+    .input(z.object({ channel: z.enum(["discord", "telegram"]) }))
+    .handler(async ({ context, input }) => {
+      const cfg = await getUserNotificationConfig(context.session.user.id);
+      if (!cfg) return { ok: false as const, error: "User notifications are disabled" };
+      const message = buildMessage("test", { appName: cfg.appName });
+      try {
+        if (input.channel === "discord") {
+          if (!cfg.discordWebhookUrl) {
+            return { ok: false as const, error: "Discord webhook is not configured" };
+          }
+          await postDiscord(cfg.discordWebhookUrl, buildDiscordComponents("test", { appName: cfg.appName }));
+        } else {
+          if (!cfg.telegramToken || !cfg.telegramChatId) {
+            return { ok: false as const, error: "Telegram is not configured" };
+          }
+          await postTelegram(cfg.telegramToken, cfg.telegramChatId, message);
+        }
+        return { ok: true as const };
+      } catch (err) {
+        return { ok: false as const, error: err instanceof Error ? err.message : "Send failed" };
+      }
+    }),
+};

--- a/packages/api/src/routers/notifications.ts
+++ b/packages/api/src/routers/notifications.ts
@@ -27,6 +27,16 @@ async function upsertSetting(key: string, value: string) {
     .onDuplicateKeyUpdate({ set: { value, updatedAt: new Date() } });
 }
 
+function resolveSecret(
+  input: string | undefined,
+  validate: (v: string) => void,
+): "keep" | "clear" | string {
+  if (input === undefined || input === SENTINEL) return "keep";
+  if (input === "") return "clear";
+  validate(input);
+  return input;
+}
+
 export const notificationsRouter = {
   getAdminConfig: adminProcedure.handler(async () => {
     const rows = await db.select().from(settings);
@@ -57,32 +67,34 @@ export const notificationsRouter = {
       if (input.discordEnabled !== undefined) pairs.push({ key: "notifications_discord_enabled", value: String(input.discordEnabled) });
       if (input.telegramEnabled !== undefined) pairs.push({ key: "notifications_telegram_enabled", value: String(input.telegramEnabled) });
       if (input.userConfigEnabled !== undefined) pairs.push({ key: "notifications_user_config_enabled", value: String(input.userConfigEnabled) });
-      if (input.discordWebhookUrl !== undefined && input.discordWebhookUrl !== SENTINEL) {
-        if (input.discordWebhookUrl === "") {
-          await db.delete(settings).where(eq(settings.key, "notifications_discord_webhook_url"));
-        } else {
-          if (!isValidDiscordWebhookUrl(input.discordWebhookUrl)) {
-            throw new ORPCError("BAD_REQUEST", { message: "Invalid Discord webhook URL" });
-          }
-          pairs.push({ key: "notifications_discord_webhook_url", value: encrypt(input.discordWebhookUrl) });
-        }
+
+      const discordWebhook = resolveSecret(input.discordWebhookUrl, (v) => {
+        if (!isValidDiscordWebhookUrl(v)) throw new ORPCError("BAD_REQUEST", { message: "Invalid Discord webhook URL" });
+      });
+      if (discordWebhook === "clear") {
+        await db.delete(settings).where(eq(settings.key, "notifications_discord_webhook_url"));
+      } else if (discordWebhook !== "keep") {
+        pairs.push({ key: "notifications_discord_webhook_url", value: encrypt(discordWebhook) });
       }
-      if (input.telegramBotToken !== undefined && input.telegramBotToken !== SENTINEL) {
-        if (input.telegramBotToken === "") {
-          await db.delete(settings).where(eq(settings.key, "notifications_telegram_bot_token"));
-        } else {
-          if (!isValidTelegramBotToken(input.telegramBotToken)) {
-            throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram bot token" });
-          }
-          pairs.push({ key: "notifications_telegram_bot_token", value: encrypt(input.telegramBotToken) });
-        }
+
+      const telegramToken = resolveSecret(input.telegramBotToken, (v) => {
+        if (!isValidTelegramBotToken(v)) throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram bot token" });
+      });
+      if (telegramToken === "clear") {
+        await db.delete(settings).where(eq(settings.key, "notifications_telegram_bot_token"));
+      } else if (telegramToken !== "keep") {
+        pairs.push({ key: "notifications_telegram_bot_token", value: encrypt(telegramToken) });
       }
-      if (input.telegramChatId !== undefined && input.telegramChatId !== SENTINEL) {
-        if (!isValidTelegramChatId(input.telegramChatId)) {
-          throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram chat id" });
-        }
-        pairs.push({ key: "notifications_telegram_chat_id", value: input.telegramChatId });
+
+      const telegramChatId = resolveSecret(input.telegramChatId, (v) => {
+        if (!isValidTelegramChatId(v)) throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram chat id" });
+      });
+      if (telegramChatId === "clear") {
+        await db.delete(settings).where(eq(settings.key, "notifications_telegram_chat_id"));
+      } else if (telegramChatId !== "keep") {
+        pairs.push({ key: "notifications_telegram_chat_id", value: telegramChatId });
       }
+
       for (const { key, value } of pairs) {
         await upsertSetting(key, value);
       }
@@ -146,32 +158,24 @@ export const notificationsRouter = {
       }
 
       const updates: Record<string, string | null> = {};
-      if (input.discordWebhookUrl !== undefined && input.discordWebhookUrl !== SENTINEL) {
-        if (input.discordWebhookUrl === "") {
-          updates.notificationDiscordWebhook = null;
-        } else {
-          if (!isValidDiscordWebhookUrl(input.discordWebhookUrl)) {
-            throw new ORPCError("BAD_REQUEST", { message: "Invalid Discord webhook URL" });
-          }
-          updates.notificationDiscordWebhook = encrypt(input.discordWebhookUrl);
-        }
-      }
-      if (input.telegramBotToken !== undefined && input.telegramBotToken !== SENTINEL) {
-        if (input.telegramBotToken === "") {
-          updates.notificationTelegramToken = null;
-        } else {
-          if (!isValidTelegramBotToken(input.telegramBotToken)) {
-            throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram bot token" });
-          }
-          updates.notificationTelegramToken = encrypt(input.telegramBotToken);
-        }
-      }
-      if (input.telegramChatId !== undefined && input.telegramChatId !== SENTINEL) {
-        if (!isValidTelegramChatId(input.telegramChatId)) {
-          throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram chat id" });
-        }
-        updates.notificationTelegramChatId = input.telegramChatId;
-      }
+      const discordWebhook = resolveSecret(input.discordWebhookUrl, (v) => {
+        if (!isValidDiscordWebhookUrl(v)) throw new ORPCError("BAD_REQUEST", { message: "Invalid Discord webhook URL" });
+      });
+      if (discordWebhook === "clear") updates.notificationDiscordWebhook = null;
+      else if (discordWebhook !== "keep") updates.notificationDiscordWebhook = encrypt(discordWebhook);
+
+      const telegramToken = resolveSecret(input.telegramBotToken, (v) => {
+        if (!isValidTelegramBotToken(v)) throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram bot token" });
+      });
+      if (telegramToken === "clear") updates.notificationTelegramToken = null;
+      else if (telegramToken !== "keep") updates.notificationTelegramToken = encrypt(telegramToken);
+
+      const telegramChatId = resolveSecret(input.telegramChatId, (v) => {
+        if (!isValidTelegramChatId(v)) throw new ORPCError("BAD_REQUEST", { message: "Invalid Telegram chat id" });
+      });
+      if (telegramChatId === "clear") updates.notificationTelegramChatId = null;
+      else if (telegramChatId !== "keep") updates.notificationTelegramChatId = telegramChatId;
+
       if (Object.keys(updates).length > 0) {
         await db.update(user).set(updates).where(eq(user.id, context.session.user.id));
       }

--- a/packages/api/src/routers/servers.ts
+++ b/packages/api/src/routers/servers.ts
@@ -18,6 +18,7 @@ import { safeDecrypt } from "../lib/crypto";
 import { signWsToken } from "../lib/jwt";
 import { buildInvocation } from "../services/wings-servers";
 import { recordActivity } from "../services/activity";
+import { notifyAdmins, notifyServerOwner } from "../services/notifications";
 import { adminProcedure, protectedProcedure } from "../index";
 
 export const serversRouter = {
@@ -585,6 +586,12 @@ export const serversRouter = {
         serverId: server.id,
         ip: context.ip,
       });
+      notifyServerOwner(server.userId, "server-power", {
+        serverName: server.name,
+        serverUuid: server.uuid,
+        action: input.action,
+        actor: context.session.user.name ?? context.session.user.email,
+      });
     }),
 
   reinstall: protectedProcedure
@@ -873,6 +880,7 @@ export const serversRouter = {
       }
 
       recordActivity({ eventType: "admin:server.create", userId: context.session.user.id, serverId: id, ip: context.ip, properties: { name: input.name } });
+      notifyAdmins("server-created", { serverName: input.name, serverUuid: uuid, actor: context.session.user.name ?? context.session.user.email });
 
       return db.query.servers.findFirst({ where: eq(servers.id, id) });
     }),
@@ -905,6 +913,7 @@ export const serversRouter = {
 
       await db.delete(servers).where(eq(servers.id, server.id));
       recordActivity({ eventType: "admin:server.delete", userId: context.session.user.id, ip: context.ip, properties: { name: server.name } });
+      notifyAdmins("server-deleted", { serverName: server.name, actor: context.session.user.name ?? context.session.user.email });
     }),
 
   getWebSocketToken: protectedProcedure

--- a/packages/api/src/routers/settings.ts
+++ b/packages/api/src/routers/settings.ts
@@ -8,7 +8,7 @@ import { deleteObject } from "../services/storage";
 import { encrypt } from "../lib/crypto";
 import { adminProcedure, publicProcedure } from "../index";
 
-const ENCRYPTED_SETTINGS_KEYS = new Set(["github_client_secret", "discord_client_secret", "google_drive_client_secret"]);
+const ENCRYPTED_SETTINGS_KEYS = new Set(["github_client_secret", "discord_client_secret", "google_drive_client_secret", "notifications_discord_webhook_url", "notifications_telegram_bot_token"]);
 
 export const settingsRouter = {
   getActiveSocialProviders: publicProcedure.handler(async () => {

--- a/packages/api/src/routers/users.ts
+++ b/packages/api/src/routers/users.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { db } from "@struxa/db";
 import { user, session, servers, nodeAllocations, nodes } from "@struxa/db";
 import { recordActivity } from "../services/activity";
+import { notifyAdmins } from "../services/notifications";
 import { adminProcedure, protectedProcedure } from "../index";
 
 export const usersRouter = {
@@ -284,7 +285,12 @@ export const usersRouter = {
       if (input.userId === context.session.user.id) {
         throw new Error("Cannot delete your own account.");
       }
+      const target = await db.query.user.findFirst({
+        where: eq(user.id, input.userId),
+        columns: { email: true },
+      });
       await db.delete(user).where(eq(user.id, input.userId));
       recordActivity({ eventType: "admin:user.delete", userId: context.session.user.id, ip: context.ip, properties: { targetUserId: input.userId } });
+      if (target) notifyAdmins("user-deleted", { userEmail: target.email, actor: context.session.user.name ?? context.session.user.email });
     }),
 };

--- a/packages/api/src/services/notifications.ts
+++ b/packages/api/src/services/notifications.ts
@@ -1,0 +1,235 @@
+import { eq } from "drizzle-orm";
+import { db } from "@struxa/db";
+import { settings } from "@struxa/db";
+import { user as userTable } from "@struxa/db";
+import { env } from "@struxa/env/server";
+import { safeDecrypt } from "../lib/crypto";
+
+export const SENTINEL = "[set]";
+
+const TIMEOUT_MS = 8000;
+
+export function isValidDiscordWebhookUrl(raw: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return false;
+  }
+  return (
+    u.protocol === "https:" &&
+    (u.hostname === "discord.com" || u.hostname === "discordapp.com") &&
+    u.pathname.startsWith("/api/webhooks/")
+  );
+}
+
+export function isValidTelegramBotToken(token: string): boolean {
+  return /^\d{6,}:[A-Za-z0-9_-]{30,}$/.test(token);
+}
+
+export function isValidTelegramChatId(id: string): boolean {
+  return /^-?\d{5,}$/.test(id);
+}
+
+export async function postDiscord(url: string, payload: object): Promise<void> {
+  if (!isValidDiscordWebhookUrl(url)) return;
+  const res = await fetch(withComponentsParam(url), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`discord ${res.status}`);
+}
+
+function withComponentsParam(url: string): string {
+  return url.includes("?") ? `${url}&with_components=true` : `${url}?with_components=true`;
+}
+
+export async function postTelegram(token: string, chatId: string, text: string): Promise<void> {
+  if (!isValidTelegramBotToken(token) || !isValidTelegramChatId(chatId)) return;
+  const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text }),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}`);
+}
+
+async function readSettingsMap(): Promise<Record<string, string>> {
+  const rows = await db.select().from(settings);
+  return Object.fromEntries(rows.map((r) => [r.key, r.value ?? ""]));
+}
+
+export async function getAdminNotificationConfig() {
+  const s = await readSettingsMap();
+  return {
+    appName: s.app_name ?? "Struxa",
+    appUrl: env.APP_URL ?? s.app_url ?? "",
+    discordEnabled: s.notifications_discord_enabled === "true",
+    discordWebhookUrl: s.notifications_discord_webhook_url ? safeDecrypt(s.notifications_discord_webhook_url) : "",
+    telegramEnabled: s.notifications_telegram_enabled === "true",
+    telegramToken: s.notifications_telegram_bot_token ? safeDecrypt(s.notifications_telegram_bot_token) : "",
+    telegramChatId: s.notifications_telegram_chat_id ?? "",
+  };
+}
+
+export async function getUserNotificationConfig(userId: string) {
+  const [s, owner] = await Promise.all([
+    readSettingsMap(),
+    db.query.user.findFirst({ where: eq(userTable.id, userId) }),
+  ]);
+  if (s.notifications_user_config_enabled !== "true" || !owner) return null;
+  return {
+    appName: s.app_name ?? "Struxa",
+    appUrl: env.APP_URL ?? s.app_url ?? "",
+    discordWebhookUrl: owner.notificationDiscordWebhook ? safeDecrypt(owner.notificationDiscordWebhook) : "",
+    telegramToken: owner.notificationTelegramToken ? safeDecrypt(owner.notificationTelegramToken) : "",
+    telegramChatId: owner.notificationTelegramChatId ?? "",
+  };
+}
+
+export function notifyAdmins(kind: string, fields: Record<string, string> = {}): void {
+  void (async () => {
+    try {
+      const cfg = await getAdminNotificationConfig();
+      const message = buildMessage(kind, { ...fields, appName: cfg.appName });
+      const components = buildDiscordComponents(kind, { ...fields, appName: cfg.appName, appUrl: cfg.appUrl });
+      if (cfg.discordEnabled && cfg.discordWebhookUrl) await postDiscord(cfg.discordWebhookUrl, components);
+      if (cfg.telegramEnabled && cfg.telegramToken && cfg.telegramChatId) {
+        await postTelegram(cfg.telegramToken, cfg.telegramChatId, message);
+      }
+    } catch (e) {
+      console.error("[notifications] admin send failed:", e);
+    }
+  })();
+}
+
+export function notifyServerOwner(ownerId: string, kind: string, fields: Record<string, string> = {}): void {
+  if (!ownerId) return;
+  void (async () => {
+    try {
+      const cfg = await getUserNotificationConfig(ownerId);
+      if (!cfg) return;
+      const message = buildMessage(kind, { ...fields, appName: cfg.appName });
+      const components = buildDiscordComponents(kind, { ...fields, appName: cfg.appName, appUrl: cfg.appUrl });
+      if (cfg.discordWebhookUrl) await postDiscord(cfg.discordWebhookUrl, components);
+      if (cfg.telegramToken && cfg.telegramChatId) {
+        await postTelegram(cfg.telegramToken, cfg.telegramChatId, message);
+      }
+    } catch (e) {
+      console.error("[notifications] user send failed:", e);
+    }
+  })();
+}
+
+export function buildMessage(kind: string, fields: Record<string, string>): string {
+  const prefix = fields.appName ?? "Struxa";
+  switch (kind) {
+    case "server-power":
+      return `[${prefix}] Server "${fields.serverName}" ${fields.action} by ${fields.actor}`;
+    case "backup":
+      return `[${prefix}] Backup "${fields.backupName}" of "${fields.serverName}" ${fields.result}`;
+    case "server-created":
+      return `[${prefix}] Server "${fields.serverName}" created`;
+    case "server-deleted":
+      return `[${prefix}] Server "${fields.serverName}" deleted`;
+    case "user-deleted":
+      return `[${prefix}] User ${fields.userEmail} deleted`;
+    case "payment":
+      return `[${prefix}] Payment ${fields.result}${fields.amount ? `: ${fields.amount} ${fields.currency}` : ""} via ${fields.provider}`;
+    case "test":
+      return `[${prefix}] Test notification`;
+    default:
+      return `[${prefix}] ${fields.message ?? ""}`;
+  }
+}
+
+const DISCORD_COMPONENTS_V2_FLAG = 32768;
+
+export function buildDiscordComponents(kind: string, fields: Record<string, string>) {
+  const appUrl = fields.appUrl ?? "";
+  let title = "Notification";
+  let subtitle = "";
+  let detail = "";
+  let buttonLabel = "Open panel";
+  let buttonUrl: string | null = appUrl || null;
+
+  switch (kind) {
+    case "server-power":
+      title = "Power action";
+      subtitle = `${fields.serverName} was ${fields.action}ed by ${fields.actor}.`;
+      detail = `**${fields.serverName}** · ${fields.action} by **${fields.actor}**`;
+      buttonLabel = "View server";
+      if (appUrl && fields.serverUuid) buttonUrl = `${appUrl}/servers/${fields.serverUuid}`;
+      break;
+    case "backup": {
+      const result = fields.result ?? "";
+      title = "Backup update";
+      subtitle = `${fields.backupName} — ${result}.`;
+      detail = `**${fields.backupName}** · ${fields.serverName}`;
+      buttonLabel = "View server";
+      if (appUrl && fields.serverUuid) buttonUrl = `${appUrl}/servers/${fields.serverUuid}`;
+      break;
+    }
+    case "server-created":
+      title = "Server created";
+      subtitle = `${fields.serverName} has been created.`;
+      detail = `**${fields.serverName}** · created by **${fields.actor}**`;
+      buttonLabel = "View server";
+      if (appUrl && fields.serverUuid) buttonUrl = `${appUrl}/servers/${fields.serverUuid}`;
+      break;
+    case "server-deleted":
+      title = "Server deleted";
+      subtitle = `${fields.serverName} has been deleted.`;
+      detail = `**${fields.serverName}** · deleted by **${fields.actor}**`;
+      buttonLabel = "View servers";
+      if (appUrl) buttonUrl = `${appUrl}/admin/servers`;
+      break;
+    case "user-deleted":
+      title = "User deleted";
+      subtitle = "A user account has been deleted.";
+      detail = `**${fields.userEmail}** · deleted by **${fields.actor}**`;
+      buttonLabel = "View users";
+      if (appUrl) buttonUrl = `${appUrl}/admin/users`;
+      break;
+    case "payment": {
+      const received = fields.result === "received";
+      title = received ? "Payment received" : "Payment failed";
+      subtitle = received ? "A wallet top-up was received." : "A wallet top-up failed.";
+      detail = fields.amount ? `**${fields.amount} ${fields.currency}** · ${fields.provider}` : `**${fields.provider}**`;
+      buttonLabel = "View billing";
+      if (appUrl) buttonUrl = `${appUrl}/admin/billing`;
+      break;
+    }
+    case "test":
+      title = "Test notification";
+      subtitle = "Notifications are working.";
+      detail = `**${fields.appName}** · Discord`;
+      break;
+  }
+
+  return componentsPayload({ title, subtitle, detail, buttonLabel, buttonUrl });
+}
+
+function componentsPayload(v: { title: string; subtitle: string; detail: string; buttonLabel: string; buttonUrl: string | null }) {
+  const header = `### ✦ ${v.title}\n${v.subtitle}`;
+  const inner: unknown[] = [];
+  if (v.buttonUrl) {
+    inner.push({
+      type: 9,
+      components: [{ type: 10, content: header }],
+      accessory: { type: 2, style: 5, label: v.buttonLabel, url: v.buttonUrl },
+    });
+    inner.push({ type:14, divider: true, spacing: 1 });
+  } else {
+    inner.push({ type: 10, content: header });
+  }
+  inner.push({ type: 10, content: v.detail });
+  inner.push({ type: 10, content: `-# <t:${Math.floor(Date.now() / 1000)}:R>` });
+  return {
+    flags: DISCORD_COMPONENTS_V2_FLAG,
+    components: [{ type: 17, accent_color: null, components: inner }],
+  };
+}

--- a/packages/api/src/services/notifications.ts
+++ b/packages/api/src/services/notifications.ts
@@ -5,7 +5,7 @@ import { user as userTable } from "@struxa/db";
 import { env } from "@struxa/env/server";
 import { safeDecrypt } from "../lib/crypto";
 
-export const SENTINEL = "[set]";
+export { SENTINEL } from "../lib/notification-constants";
 
 const TIMEOUT_MS = 8000;
 
@@ -32,7 +32,7 @@ export function isValidTelegramChatId(id: string): boolean {
 }
 
 export async function postDiscord(url: string, payload: object): Promise<void> {
-  if (!isValidDiscordWebhookUrl(url)) return;
+  if (!isValidDiscordWebhookUrl(url)) throw new Error("Invalid Discord webhook URL");
   const res = await fetch(withComponentsParam(url), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -47,7 +47,9 @@ function withComponentsParam(url: string): string {
 }
 
 export async function postTelegram(token: string, chatId: string, text: string): Promise<void> {
-  if (!isValidTelegramBotToken(token) || !isValidTelegramChatId(chatId)) return;
+  if (!isValidTelegramBotToken(token) || !isValidTelegramChatId(chatId)) {
+    throw new Error("Invalid Telegram configuration");
+  }
   const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -230,6 +232,7 @@ function componentsPayload(v: { title: string; subtitle: string; detail: string;
   inner.push({ type: 10, content: `-# <t:${Math.floor(Date.now() / 1000)}:R>` });
   return {
     flags: DISCORD_COMPONENTS_V2_FLAG,
+    allowed_mentions: { parse: [] },
     components: [{ type: 17, accent_color: null, components: inner }],
   };
 }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -18,6 +18,7 @@ import {
   substituteVars,
   sendEmail,
 } from "./email";
+import { notifyAdminsSignup } from "./notifications";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AuthInstance = any;
@@ -122,6 +123,7 @@ async function buildAuth(): Promise<AuthInstance> {
         if (ctx.path !== "/sign-up/email") return;
         const newUser = ctx.context.newSession?.user;
         if (!newUser) return;
+        notifyAdminsSignup(newUser.email ?? "", newUser.name ?? "");
         void (async () => {
           try {
             const svc = await buildEmailServiceFromSettings();

--- a/packages/auth/src/notifications.ts
+++ b/packages/auth/src/notifications.ts
@@ -41,6 +41,7 @@ export function notifyAdminsSignup(userEmail: string, userName: string): void {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             flags: 32768,
+            allowed_mentions: { parse: [] },
             components: [{ type: 17, accent_color: null, components: inner }],
           }),
           signal: AbortSignal.timeout(TIMEOUT_MS),

--- a/packages/auth/src/notifications.ts
+++ b/packages/auth/src/notifications.ts
@@ -1,0 +1,64 @@
+import { db, settings } from "@struxa/db";
+import { env } from "@struxa/env/server";
+import { safeDecrypt } from "./lib/crypto";
+
+const TIMEOUT_MS = 8000;
+
+export function notifyAdminsSignup(userEmail: string, userName: string): void {
+  void (async () => {
+    try {
+      const rows = await db.select().from(settings);
+      const s = Object.fromEntries(rows.map((r) => [r.key, r.value ?? ""]));
+      if (
+        s.notifications_discord_enabled !== "true" &&
+        s.notifications_telegram_enabled !== "true"
+      ) {
+        return;
+      }
+      const appName = s.app_name ?? "Struxa";
+      const appUrl = env.APP_URL ?? s.app_url ?? "";
+      const message = `[${appName}] New user registered: ${userEmail} (${userName})`;
+      if (s.notifications_discord_enabled === "true" && s.notifications_discord_webhook_url) {
+        const url = safeDecrypt(s.notifications_discord_webhook_url);
+        const header = `### ✦ User created\nA new member has joined your ${appName} workspace.`;
+        const inner: unknown[] = [];
+        if (appUrl) {
+          inner.push(
+            {
+              type: 9,
+              components: [{ type: 10, content: header }],
+              accessory: { type: 2, style: 5, label: "View user", url: `${appUrl}/admin/users` },
+            },
+            { type: 14, divider: true, spacing: 1 },
+          );
+        } else {
+          inner.push({ type: 10, content: header });
+        }
+        inner.push({ type: 10, content: `**${userEmail}** · ${userName}` });
+        inner.push({ type: 10, content: `-# <t:${Math.floor(Date.now() / 1000)}:R>` });
+        await fetch(url.includes("?") ? `${url}&with_components=true` : `${url}?with_components=true`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            flags: 32768,
+            components: [{ type: 17, accent_color: null, components: inner }],
+          }),
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        });
+      }
+      if (
+        s.notifications_telegram_enabled === "true" &&
+        s.notifications_telegram_bot_token &&
+        s.notifications_telegram_chat_id
+      ) {
+        const token = safeDecrypt(s.notifications_telegram_bot_token);
+        await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ chat_id: s.notifications_telegram_chat_id, text: message }),
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        });
+      }
+    } catch {}
+  })();
+}

--- a/packages/db/src/migrations/0010_add_user_notifications.sql
+++ b/packages/db/src/migrations/0010_add_user_notifications.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `user` ADD `notification_discord_webhook` text;--> statement-breakpoint
+ALTER TABLE `user` ADD `notification_telegram_token` text;--> statement-breakpoint
+ALTER TABLE `user` ADD `notification_telegram_chat_id` text;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1787239128488,
       "tag": "0009_concerned_maddog",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "5",
+      "when": 1787498400000,
+      "tag": "0010_add_user_notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -40,6 +40,9 @@ export const user = mysqlTable("user", {
   vatCountry: varchar("vat_country", { length: 2 }),
   // i18n
   locale: varchar("locale", { length: 10 }).default("en").notNull(),
+  notificationDiscordWebhook: text("notification_discord_webhook"),
+  notificationTelegramToken: text("notification_telegram_token"),
+  notificationTelegramChatId: text("notification_telegram_chat_id"),
 });
 
 export const session = mysqlTable(


### PR DESCRIPTION
Outbound notifications for admins and users via Discord (Components V2 embeds) and Telegram bots.

- Admin settings: Notification Endpoints list (Discord webhook, Telegram bot) with per-channel test buttons, plus a toggle that allows or disallows users configuring their own notifications.
- Account settings: Notifications tab (hidden while disabled by admin) where users configure their own endpoints.
- Events:
  - admins: user signup, user deleted, server created/deleted, payments received/failed, server offline/online
  - server owners: power actions, backup start/delete/restore/completion, server offline/online
- Secrets (webhook URLs, bot tokens) encrypted at rest; Discord URLs validated on save and at send time.
- Watchkeeper sends offline/online transitions using the same Discord embed template.
- DB: three new nullable columns on user (migration 0010).

Not included (follow-ups): suspend/ban events, subuser notifications, per-event toggles.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790525809&installation_model_id=22253&pr_number=29&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F29&signature=f03720389b29547aaf134b4e851bfa0f5de8561d9391d6fd7becca678b3b0725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord and Telegram notification setup for administrators and account holders.
  * Added test-send controls and notification configuration tabs.
  * Notifications now cover server status, backups, payments, user signups, and administrative actions.
  * Added secure storage for notification credentials.

* **Bug Fixes**
  * Notification delivery failures are handled without interrupting related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->