### PR TITLE
fix(stats): guard missing load_average in wings stats messages

### DIFF
--- a/apps/web/src/hooks/use-system-stats.ts
+++ b/apps/web/src/hooks/use-system-stats.ts
@@ -124,6 +124,7 @@ export function useSystemStats(node: StatsNode, options?: { enabled?: boolean })
           try {
             const stats = JSON.parse(event.data) as SystemStatsMessage;
             if (typeof stats.cpu?.used !== "number") return;
+            stats.load_average ??= { one: 0, five: 0, fifteen: 0 };
             setLatest(stats);
             counterRef.current += 1;
             if (counterRef.current % SAMPLE_EVERY !== 0) return;
@@ -209,6 +210,7 @@ export function useFleetStats(nodes: StatsNode[] | undefined) {
             try {
               const stats = JSON.parse(event.data) as SystemStatsMessage;
               if (typeof stats.cpu?.used !== "number") return;
+              stats.load_average ??= { one: 0, five: 0, fifteen: 0 };
               latestMap.set(node.id, stats);
               const count = (counters.get(node.id) ?? 0) + 1;
               counters.set(node.id, count);


### PR DESCRIPTION
Older wings builds (pre-1.2.4) don't include `load_average` in the stats websocket payload. The admin monitoring page accessed `latest.load_average.one` directly and crashed with `can't access property \"one\", load_average is undefined`.

Normalizes `load_average` to zeros in both stats hooks when absent, so the panel no longer crashes while nodes are running older wings images.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790532877&installation_model_id=22253&pr_number=30&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F30&signature=13b92e4e1a1624aa3bc2fdd546294aec538d9089789a64ceb3f7a27d9691a5a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system and fleet monitoring stability when incoming statistics omit load average data.
  * Missing load average values now display as zero instead of causing incomplete or unreliable stats updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->