### PR TITLE
Update page.tsx

### DIFF
--- a/apps/web/src/app/(panel)/billing/wallet/page.tsx
+++ b/apps/web/src/app/(panel)/billing/wallet/page.tsx
@@ -181,7 +181,7 @@ export default function WalletPage() {
 
   const { data: wallet, refetch: refetchWallet } = useQuery(orpc.billing.getWallet.queryOptions());
   const { data: txRaw = [], isLoading: txLoading, refetch: refetchTransactions } = useQuery(
-    orpc.billing.listWalletTransactions.queryOptions({ limit: TX_PAGE_SIZE + 1, offset: txPage * TX_PAGE_SIZE }),
+    orpc.billing.listWalletTransactions.queryOptions({ input: { limit: TX_PAGE_SIZE + 1, offset: txPage * TX_PAGE_SIZE } }),
   );
   const hasNextPage = txRaw.length > TX_PAGE_SIZE;
   const transactions = txRaw.slice(0, TX_PAGE_SIZE);


### PR DESCRIPTION
Zmiana 2/2


## Summary

<!-- Describe what this PR does and why. -->

## Changes

listProducts i listWalletTransactions były wywoływane bez opakowania parametrów w { input: {...} }, przez co argumenty były po cichu gubione przez klienta oRPC tanstack-query i nigdy nie docierały do serwera.

- strona kategorii sklepu (/billing/[slug]) zawsze pobierała WSZYSTKIE aktywne produkty niezależnie od kategorii, więc każda kategoria (np. Minecraft, BeamMP) pokazywała każdy plan hostingowy zamiast tylko swoich
- lista transakcji portfela zawsze ignorowała limit/offset, przez co paginacja na /billing/wallet po cichu nic nie robiła

## Testing

<!-- Describe how you tested these changes. -->

- [x] I have tested this manually
- [x] Existing functionality is unaffected

## Checklist

- [x] My changes follow the project's conventions
- [ ] I have updated relevant documentation
- [x] No secrets or sensitive data are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791523823&installation_model_id=22253&pr_number=32&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F32&signature=16c6867a58fa1f97387d32ad876a59c2af476280227067cffa72036feee5954a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Wallet transaction history now correctly applies pagination parameters when retrieving results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->