### PR TITLE
Update page.tsx

### DIFF
--- a/apps/web/src/app/(panel)/billing/[slug]/page.tsx
+++ b/apps/web/src/app/(panel)/billing/[slug]/page.tsx
@@ -947,7 +947,7 @@ export default function BillingCategoryPage({
   const category = categories.find((c) => c.slug === slug);
 
   const { data: products = [], isLoading: productsLoading } = useQuery({
-    ...orpc.billing.listProducts.queryOptions({ categoryId: category?.id }),
+    ...orpc.billing.listProducts.queryOptions({ input: { categoryId: category?.id } }),
     enabled: !!category?.id,
   });
 


### PR DESCRIPTION
Zmiana 1/2

## Summary

<!-- Describe what this PR does and why. -->

## Changes

listProducts i listWalletTransactions były wywoływane bez opakowania parametrów w { input: {...} }, przez co argumenty były po cichu gubione przez klienta oRPC tanstack-query i nigdy nie docierały do serwera.

- strona kategorii sklepu (/billing/[slug]) zawsze pobierała WSZYSTKIE aktywne produkty niezależnie od kategorii, więc każda kategoria (np. Minecraft, BeamMP) pokazywała każdy plan hostingowy zamiast tylko swoich
- lista transakcji portfela zawsze ignorowała limit/offset, przez co paginacja na /billing/wallet po cichu nic nie robiła
- 

## Testing

<!-- Describe how you tested these changes. -->

- [x] I have tested this manually
- [x] Existing functionality is unaffected

## Checklist

- [x] My changes follow the project's conventions
- [ ] I have updated relevant documentation
- [x] No secrets or sensitive data are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/struxadotcloud/codesmith/struxa/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791524040&installation_model_id=22253&pr_number=33&repository=struxadotcloud%2Fstruxa&return_to=https%3A%2F%2Fgithub.com%2Fstruxadotcloud%2Fstruxa%2Fpull%2F33&signature=36fd26be36eec608134f0e74bdd34d930b0032f7fac1b6436c65dd4246d047bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->